### PR TITLE
Prefer ATTIO_API_KEY, remove hard .env loads, and add AttioClient tests

### DIFF
--- a/agent/helper/attio.py
+++ b/agent/helper/attio.py
@@ -58,9 +58,9 @@ class AttioClient:
         self._client: httpx.AsyncClient | None = None
 
     async def __aenter__(self) -> AttioClient:
-        token = os.environ.get("ATTIO_KEY")
+        token = os.environ.get("ATTIO_API_KEY") or os.environ.get("ATTIO_KEY")
         if not token:
-            raise RuntimeError("ATTIO_KEY must be set")
+            raise RuntimeError("ATTIO_API_KEY must be set (ATTIO_KEY is accepted as a temporary fallback)")
         self._client = httpx.AsyncClient(
             base_url=BASE_URL,
             headers={

--- a/agent/helper/tools.py
+++ b/agent/helper/tools.py
@@ -9,13 +9,9 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from email.utils import parseaddr
-from pathlib import Path
 from typing import Any
 
 import httpx
-from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parents[2] / "backend" / ".env")
 
 from helper.attio import AttioClient, flatten_record
 

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -27,10 +27,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from dotenv import load_dotenv
 from fastmcp import FastMCP
-
-load_dotenv(Path(__file__).parents[1] / "backend" / ".env")
 
 from helper.attio import AttioClient, flatten_record
 

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -4,11 +4,13 @@ Pytest configuration for agent integration tests.
 Env vars are loaded from Doppler when run via:
     doppler run -- python -m pytest tests/ -v
 
-Falls back to a local .env file for editors/IDEs that run pytest directly.
+Falls back to a local repo .env file for editors/IDEs that run pytest directly.
 """
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-# No-op if the file doesn't exist; Doppler vars take precedence (override=False)
-load_dotenv(Path(__file__).parents[2] / "backend" / ".env", override=False)
+_repo_env = Path(__file__).resolve().parents[2] / ".env"
+if _repo_env.is_file():
+    # Doppler vars take precedence (override=False).
+    load_dotenv(_repo_env, override=False)

--- a/agent/tests/test_attio_env.py
+++ b/agent/tests/test_attio_env.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from helper.attio import AttioClient
+
+
+@pytest.mark.asyncio
+async def test_attio_client_prefers_attio_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATTIO_API_KEY", "primary-token")
+    monkeypatch.setenv("ATTIO_KEY", "legacy-token")
+
+    async with AttioClient() as client:
+        assert client._client is not None
+        assert client._client.headers["Authorization"] == "Bearer primary-token"
+
+
+@pytest.mark.asyncio
+async def test_attio_client_falls_back_to_attio_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATTIO_API_KEY", raising=False)
+    monkeypatch.setenv("ATTIO_KEY", "legacy-token")
+
+    async with AttioClient() as client:
+        assert client._client is not None
+        assert client._client.headers["Authorization"] == "Bearer legacy-token"
+
+
+@pytest.mark.asyncio
+async def test_attio_client_requires_configured_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATTIO_API_KEY", raising=False)
+    monkeypatch.delenv("ATTIO_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="ATTIO_API_KEY must be set"):
+        async with AttioClient():
+            pass


### PR DESCRIPTION
### Motivation

- Prefer the newer `ATTIO_API_KEY` environment variable while preserving `ATTIO_KEY` as a temporary fallback and provide a clearer error message if neither is set.
- Stop implicitly loading a `backend/.env` from library code so environment configuration is centralized and not forced when the agent runs as a separate process.
- Make CI and local expectations explicit by adjusting test env loading to check the repo `.env` and add unit tests that validate the `AttioClient` environment handling.

### Description

- Update `AttioClient.__aenter__` to read `ATTIO_API_KEY` first, fall back to `ATTIO_KEY`, and change the `RuntimeError` text to reference `ATTIO_API_KEY` with a note about the fallback.
- Remove automatic `load_dotenv` calls and the `Path` import from `agent/helper/tools.py` and remove `load_dotenv` from `agent/mcp_server.py` so the agent no longer forces loading `backend/.env`.
- Change `agent/tests/conftest.py` to conditionally load a repo-level `.env` (`<repo>/.env`) only if it exists and to keep Doppler/overrides behavior.
- Add `agent/tests/test_attio_env.py` with three `pytest.mark.asyncio` tests that assert preference for `ATTIO_API_KEY`, fallback to `ATTIO_KEY`, and raise a `RuntimeError` when neither is set.

### Testing

- Ran the new Attio client unit tests with `pytest -q agent/tests/test_attio_env.py` and all tests passed.
- No other automated test failures were observed when running the local test subset used for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd60f381c4833387fb4abfd045c5f1)