### PR TITLE
Add /agent primary workspace with 3-panel layout

### DIFF
--- a/fe+convex/app/agent/layout.tsx
+++ b/fe+convex/app/agent/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSession } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function AgentLayout({ children }: { children: React.ReactNode }) {
+  const { data: session, isPending } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isPending && !session) {
+      router.replace("/login?redirect=/agent");
+    }
+  }, [isPending, router, session]);
+
+  if (isPending) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA]">
+        <p className="text-[13px] text-[#999999]">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) return null;
+
+  return <>{children}</>;
+}

--- a/fe+convex/app/agent/page.tsx
+++ b/fe+convex/app/agent/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { LayoutDashboard } from "lucide-react";
+import { ThreadRail } from "@/components/agent/ThreadRail";
+import { ConversationTimeline } from "@/components/agent/ConversationTimeline";
+import { ArtifactCanvas } from "@/components/agent/ArtifactCanvas";
+import type { AgentThread, AgentArtifact } from "@/components/agent/types";
+import { getThreadArtifacts } from "@/components/agent/adapters/mock";
+
+export default function AgentPage() {
+  const [activeThread, setActiveThread] = useState<AgentThread | null>(null);
+  const [artifacts, setArtifacts] = useState<AgentArtifact[]>([]);
+  const [canvasOpen, setCanvasOpen] = useState(false);
+
+  async function loadThread(thread: AgentThread) {
+    setActiveThread(thread);
+    const arts = await getThreadArtifacts(thread.id);
+    setArtifacts(arts);
+    setCanvasOpen(arts.length > 0);
+  }
+
+  const handleArtifactsChange = useCallback(async () => {
+    if (!activeThread) return;
+    const arts = await getThreadArtifacts(activeThread.id);
+    setArtifacts(arts);
+    if (arts.length > 0) setCanvasOpen(true);
+  }, [activeThread]);
+
+  return (
+    <div
+      className="flex h-screen bg-[#FFFFFF] text-[#111111]"
+      style={{ fontFamily: "var(--font-geist-sans)" }}
+    >
+      {/* Left rail */}
+      <ThreadRail
+        activeThreadId={activeThread?.id ?? null}
+        onSelectThread={loadThread}
+        onNewThread={(thread) => {
+          setActiveThread(thread);
+          setArtifacts([]);
+          setCanvasOpen(false);
+        }}
+      />
+
+      {/* Center — conversation */}
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Top bar */}
+        <div className="flex h-[60px] shrink-0 items-center justify-between border-b border-[#EBEBEB] px-5">
+          {/* Thread title (or logo when no thread selected) */}
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            {activeThread ? (
+              <>
+                <h2 className="truncate text-[13.5px] font-semibold text-[#111111]">
+                  {activeThread.title}
+                </h2>
+                {activeThread.contextLinks?.map((link) => (
+                  <span
+                    key={link.id}
+                    className="shrink-0 rounded-full border border-[#E0E0E0] px-2 py-0.5 text-[10.5px] font-medium text-[#555555]"
+                  >
+                    {link.label}
+                  </span>
+                ))}
+              </>
+            ) : (
+              <>
+                <div className="h-5 w-5 rounded-[6px] bg-[#0A0A0A]" />
+                <span className="text-[13px] font-semibold tracking-[-0.01em] text-[#111111]">
+                  event.organizer
+                </span>
+              </>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            {artifacts.length > 0 && !canvasOpen && (
+              <button
+                onClick={() => setCanvasOpen(true)}
+                className="rounded-[6px] border border-[#E0E0E0] px-2.5 py-1 text-[12px] font-medium text-[#555555] transition-colors duration-100 hover:bg-[#F4F4F4]"
+              >
+                Artifacts ({artifacts.length})
+              </button>
+            )}
+            <Link
+              href="/dashboard"
+              className="flex items-center gap-1.5 rounded-[6px] border border-[#E0E0E0] px-2.5 py-1 text-[12px] font-medium text-[#555555] transition-colors duration-100 hover:bg-[#F4F4F4]"
+            >
+              <LayoutDashboard className="h-3.5 w-3.5" strokeWidth={1.8} />
+              Dashboard
+            </Link>
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <ConversationTimeline
+          thread={activeThread}
+          onArtifactsChange={handleArtifactsChange}
+        />
+      </div>
+
+      {/* Right — artifact canvas */}
+      {canvasOpen && (
+        <div
+          className="w-[320px] shrink-0"
+          style={{
+            animation: "canvasSlideIn 180ms cubic-bezier(0.23, 1, 0.32, 1) both",
+          }}
+        >
+          <ArtifactCanvas
+            artifacts={artifacts}
+            onClose={() => setCanvasOpen(false)}
+          />
+        </div>
+      )}
+
+      <style>{`
+        @keyframes canvasSlideIn {
+          from { opacity: 0; transform: translateX(12px); }
+          to   { opacity: 1; transform: translateX(0); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/fe+convex/app/dashboard/layout.tsx
+++ b/fe+convex/app/dashboard/layout.tsx
@@ -13,10 +13,16 @@ import {
   Mail,
   Ticket,
   Users,
+  Zap,
   type LucideIcon,
 } from "lucide-react";
 
 const navLinks = [
+  {
+    href: "/agent",
+    label: "Agent",
+    icon: Zap,
+  },
   {
     href: "/dashboard",
     label: "Dashboard",
@@ -99,7 +105,9 @@ export default function DashboardLayout({
               {navLinks.map((link) => {
                 const active =
                   pathname === link.href ||
-                  (link.href !== "/dashboard" && pathname.startsWith(link.href));
+                  (link.href !== "/dashboard" &&
+                    link.href !== "/agent" &&
+                    pathname.startsWith(link.href));
                 return (
                   <Link
                     key={link.href}

--- a/fe+convex/components/agent/AgentInput.tsx
+++ b/fe+convex/components/agent/AgentInput.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRef, useState, type KeyboardEvent } from "react";
+import { ArrowUp } from "lucide-react";
+
+interface AgentInputProps {
+  onSubmit: (text: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function AgentInput({
+  onSubmit,
+  disabled = false,
+  placeholder = "Message the agent…",
+}: AgentInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleSubmit() {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSubmit(trimmed);
+    setValue("");
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  function handleInput() {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }
+
+  const canSend = value.trim().length > 0 && !disabled;
+
+  return (
+    <div className="border-t border-[#EBEBEB] bg-[#FFFFFF] px-4 py-3">
+      <div className="relative flex items-end gap-2 rounded-[10px] border border-[#E0E0E0] bg-[#FAFAFA] px-3 py-2.5 transition-colors duration-100 focus-within:border-[#CFCFCF] focus-within:bg-[#FFFFFF]">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onInput={handleInput}
+          disabled={disabled}
+          rows={1}
+          placeholder={placeholder}
+          className="max-h-40 flex-1 resize-none bg-transparent text-[13.5px] leading-[1.5] text-[#111111] placeholder:text-[#BBBBBB] focus:outline-none disabled:opacity-50"
+          style={{ fontFamily: "var(--font-geist-sans)" }}
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={!canSend}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px] bg-[#0A0A0A] text-white transition-all duration-100 hover:bg-[#222222] active:scale-[0.93] disabled:bg-[#E0E0E0] disabled:text-[#BBBBBB]"
+          style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+          aria-label="Send message"
+        >
+          <ArrowUp className="h-4 w-4" strokeWidth={2.2} />
+        </button>
+      </div>
+      <p className="mt-1.5 px-1 text-[11px] text-[#BBBBBB]">
+        Enter to send · Shift+Enter for new line
+      </p>
+    </div>
+  );
+}

--- a/fe+convex/components/agent/ApprovalCard.tsx
+++ b/fe+convex/components/agent/ApprovalCard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Check, X } from "lucide-react";
+import type { AgentApproval, RiskLevel } from "./types";
+import { submitApproval } from "./adapters/mock";
+
+interface ApprovalCardProps {
+  approval: AgentApproval;
+  onDecision?: (decision: "approved" | "rejected") => void;
+}
+
+const riskConfig: Record<RiskLevel, { label: string; color: string; border: string }> = {
+  low: {
+    label: "Low risk",
+    color: "text-[#555555]",
+    border: "border-[#E0E0E0]",
+  },
+  medium: {
+    label: "Review required",
+    color: "text-[#555555]",
+    border: "border-[#CFCFCF]",
+  },
+  high: {
+    label: "High risk",
+    color: "text-[#0A0A0A]",
+    border: "border-[#0A0A0A]",
+  },
+};
+
+export function ApprovalCard({ approval, onDecision }: ApprovalCardProps) {
+  const [status, setStatus] = useState<"pending" | "approved" | "rejected">(approval.status);
+  const [loading, setLoading] = useState(false);
+
+  const risk = riskConfig[approval.riskLevel];
+
+  async function decide(decision: "approved" | "rejected") {
+    if (loading || status !== "pending") return;
+    setLoading(true);
+    try {
+      await submitApproval(approval.id, decision);
+      setStatus(decision);
+      onDecision?.(decision);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      className={`mx-auto max-w-[520px] rounded-[10px] border bg-[#FFFFFF] ${risk.border}`}
+      style={{
+        animation: "approvalIn 200ms cubic-bezier(0.23, 1, 0.32, 1) both",
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3 border-b border-[#EBEBEB] px-4 py-3">
+        <AlertTriangle
+          className={`mt-0.5 h-4 w-4 shrink-0 ${risk.color}`}
+          strokeWidth={1.8}
+        />
+        <div>
+          <p className="text-[12.5px] font-semibold text-[#0A0A0A]">Approval required</p>
+          <p className={`text-[11.5px] ${risk.color}`}>{risk.label}</p>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3">
+        <p className="text-[13px] font-medium leading-snug text-[#111111]">
+          {approval.requestedAction}
+        </p>
+
+        {Object.keys(approval.proposedPayload).length > 0 && (
+          <div className="mt-2 rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-2">
+            <pre className="whitespace-pre-wrap break-all font-mono text-[11px] text-[#555555]">
+              {JSON.stringify(approval.proposedPayload, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-2 border-t border-[#EBEBEB] px-4 py-2.5">
+        {status === "pending" ? (
+          <>
+            <button
+              onClick={() => decide("rejected")}
+              disabled={loading}
+              className="flex h-8 items-center gap-1.5 rounded-[6px] border border-[#E0E0E0] px-3 text-[12.5px] font-medium text-[#555555] transition-colors duration-100 hover:border-[#CFCFCF] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              <X className="h-3.5 w-3.5" strokeWidth={2} />
+              Reject
+            </button>
+            <button
+              onClick={() => decide("approved")}
+              disabled={loading}
+              className="flex h-8 items-center gap-1.5 rounded-[6px] bg-[#0A0A0A] px-3 text-[12.5px] font-medium text-white transition-colors duration-100 hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              <Check className="h-3.5 w-3.5" strokeWidth={2.2} />
+              Approve
+            </button>
+          </>
+        ) : (
+          <span
+            className={`text-[12px] font-medium ${
+              status === "approved" ? "text-[#555555]" : "text-[#999999]"
+            }`}
+          >
+            {status === "approved" ? "Approved" : "Rejected"}
+          </span>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes approvalIn {
+          from { opacity: 0; transform: translateY(6px) scale(0.98); }
+          to   { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/fe+convex/components/agent/ArtifactCanvas.tsx
+++ b/fe+convex/components/agent/ArtifactCanvas.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, LayoutGrid, X } from "lucide-react";
+import type { AgentArtifact, TableData, MetricGroupData, ChecklistData } from "./types";
+
+interface ArtifactCanvasProps {
+  artifacts: AgentArtifact[];
+  onClose?: () => void;
+}
+
+export function ArtifactCanvas({ artifacts, onClose }: ArtifactCanvasProps) {
+  const [index, setIndex] = useState(artifacts.length - 1);
+
+  const artifact = artifacts[index];
+
+  if (artifacts.length === 0 || !artifact) {
+    return (
+      <div className="flex h-full items-center justify-center border-l border-[#EBEBEB] bg-[#FAFAFA]">
+        <div className="text-center">
+          <LayoutGrid className="mx-auto h-7 w-7 text-[#CFCFCF]" strokeWidth={1.5} />
+          <p className="mt-3 text-[12px] text-[#BBBBBB]">Artifacts will appear here</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col border-l border-[#EBEBEB] bg-[#FAFAFA]">
+      {/* Header */}
+      <div className="flex h-[60px] items-center justify-between border-b border-[#EBEBEB] px-4">
+        <div className="min-w-0 flex-1">
+          <p
+            className="truncate text-[12.5px] font-semibold text-[#111111]"
+            style={{ fontFamily: "var(--font-geist-sans)" }}
+          >
+            {artifact.title}
+          </p>
+          <p className="text-[11px] text-[#BBBBBB]">{artifact.type.replace("_", " ")}</p>
+        </div>
+        <div className="flex items-center gap-1 pl-2">
+          {artifacts.length > 1 && (
+            <>
+              <button
+                onClick={() => setIndex((i) => Math.max(0, i - 1))}
+                disabled={index === 0}
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#999999] hover:bg-[#EBEBEB] disabled:opacity-30"
+                aria-label="Previous artifact"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <span className="text-[11px] text-[#BBBBBB]">
+                {index + 1}/{artifacts.length}
+              </span>
+              <button
+                onClick={() => setIndex((i) => Math.min(artifacts.length - 1, i + 1))}
+                disabled={index === artifacts.length - 1}
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#999999] hover:bg-[#EBEBEB] disabled:opacity-30"
+                aria-label="Next artifact"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </>
+          )}
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#999999] hover:bg-[#EBEBEB]"
+              aria-label="Close canvas"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Artifact body */}
+      <div className="flex-1 overflow-y-auto p-4">
+        <ArtifactRenderer artifact={artifact} />
+      </div>
+    </div>
+  );
+}
+
+function ArtifactRenderer({ artifact }: { artifact: AgentArtifact }) {
+  switch (artifact.type) {
+    case "table":
+      return <TableArtifact data={artifact.data as TableData} />;
+    case "metric_group":
+      return <MetricGroupArtifact data={artifact.data as MetricGroupData} />;
+    case "checklist":
+      return <ChecklistArtifact data={artifact.data as ChecklistData} />;
+    default:
+      return (
+        <div className="rounded-[8px] border border-[#E0E0E0] bg-[#FFFFFF] p-4">
+          <pre className="whitespace-pre-wrap break-all font-mono text-[11px] text-[#555555]">
+            {JSON.stringify(artifact.data, null, 2)}
+          </pre>
+        </div>
+      );
+  }
+}
+
+function TableArtifact({ data }: { data: TableData }) {
+  return (
+    <div className="overflow-hidden rounded-[8px] border border-[#E0E0E0] bg-[#FFFFFF]">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-[12.5px]">
+          <thead>
+            <tr className="border-b border-[#EBEBEB] bg-[#FAFAFA]">
+              {data.columns.map((col) => (
+                <th
+                  key={col}
+                  className="h-9 whitespace-nowrap px-3 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-[#999999]"
+                >
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.map((row, ri) => (
+              <tr
+                key={ri}
+                className="border-b border-[#F4F4F4] transition-colors duration-75 last:border-0 hover:bg-[#FAFAFA]"
+              >
+                {row.map((cell, ci) => (
+                  <td key={ci} className="px-3 py-2.5 text-[12.5px] text-[#333333]">
+                    {cell ?? "—"}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function MetricGroupArtifact({ data }: { data: MetricGroupData }) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {data.metrics.map((metric, i) => (
+        <div
+          key={i}
+          className="rounded-[8px] border border-[#E0E0E0] bg-[#FFFFFF] px-3.5 py-3"
+        >
+          <p className="text-[11px] font-medium uppercase tracking-[0.06em] text-[#999999]">
+            {metric.label}
+          </p>
+          <p className="mt-1 text-[22px] font-semibold tracking-[-0.02em] text-[#0A0A0A]">
+            {metric.value}
+          </p>
+          {metric.delta && (
+            <p
+              className={`mt-0.5 text-[11.5px] ${
+                metric.deltaDirection === "up"
+                  ? "text-[#555555]"
+                  : metric.deltaDirection === "down"
+                    ? "text-[#999999]"
+                    : "text-[#BBBBBB]"
+              }`}
+            >
+              {metric.delta}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChecklistArtifact({ data }: { data: ChecklistData }) {
+  const [items, setItems] = useState(data.items);
+
+  function toggle(id: string) {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, checked: !item.checked } : item)),
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          onClick={() => toggle(item.id)}
+          className="flex w-full items-start gap-3 rounded-[8px] border border-transparent px-3 py-2.5 text-left transition-colors duration-100 hover:border-[#EBEBEB] hover:bg-[#FFFFFF]"
+        >
+          <div
+            className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors duration-100 ${
+              item.checked
+                ? "border-[#0A0A0A] bg-[#0A0A0A]"
+                : "border-[#CFCFCF] bg-transparent"
+            }`}
+          >
+            {item.checked && (
+              <svg viewBox="0 0 10 8" className="h-2.5 w-2.5 fill-none stroke-white stroke-[1.8]">
+                <path d="M1 4l3 3 5-6" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </div>
+          <div>
+            <p
+              className={`text-[13px] leading-snug ${
+                item.checked ? "text-[#BBBBBB] line-through" : "text-[#111111]"
+              }`}
+            >
+              {item.label}
+            </p>
+            {item.notes && (
+              <p className="mt-0.5 text-[11.5px] text-[#999999]">{item.notes}</p>
+            )}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { AgentMessage, AgentApproval, AgentThread } from "./types";
+import { MessageBubble } from "./MessageBubble";
+import { ApprovalCard } from "./ApprovalCard";
+import { AgentInput } from "./AgentInput";
+import {
+  getThreadMessages,
+  getThreadApprovals,
+  startRun,
+} from "./adapters/mock";
+
+interface ConversationTimelineProps {
+  thread: AgentThread | null;
+  onArtifactsChange?: () => void;
+}
+
+export function ConversationTimeline({ thread, onArtifactsChange }: ConversationTimelineProps) {
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [approvals, setApprovals] = useState<AgentApproval[]>([]);
+  const [streamingText, setStreamingText] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const threadIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!thread) {
+      setMessages([]);
+      setApprovals([]);
+      setLoaded(true);
+      return;
+    }
+
+    if (thread.id === threadIdRef.current) return;
+    threadIdRef.current = thread.id;
+    setLoaded(false);
+    setMessages([]);
+    setApprovals([]);
+    setStreamingText(null);
+
+    Promise.all([getThreadMessages(thread.id), getThreadApprovals(thread.id)]).then(
+      ([msgs, apps]) => {
+        if (threadIdRef.current !== thread.id) return;
+        setMessages(msgs);
+        setApprovals(apps);
+        setLoaded(true);
+      },
+    );
+  }, [thread]);
+
+  // Scroll to bottom when messages change or streaming updates
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, streamingText]);
+
+  async function handleSend(text: string) {
+    if (!thread || isRunning) return;
+    setIsRunning(true);
+    setStreamingText("");
+
+    // Optimistically show user message
+    const optimisticUser: AgentMessage = {
+      id: `opt-user-${Date.now()}`,
+      threadId: thread.id,
+      role: "user",
+      content: [{ type: "text", text }],
+      createdAt: Date.now(),
+    };
+    setMessages((prev) => [...prev, optimisticUser]);
+
+    try {
+      await startRun(
+        thread.id,
+        text,
+        (chunk) => setStreamingText(chunk),
+        (done) => {
+          setStreamingText(null);
+          // Replace optimistic user message with real messages from adapter
+          setMessages((prev) => {
+            const withoutOptimistic = prev.filter((m) => m.id !== optimisticUser.id);
+            return [...withoutOptimistic, optimisticUser, done];
+          });
+          onArtifactsChange?.();
+        },
+      );
+    } finally {
+      setIsRunning(false);
+      setStreamingText(null);
+    }
+  }
+
+  const pendingApprovals = approvals.filter((a) => a.status === "pending");
+
+  if (!thread) {
+    return (
+      <div className="flex flex-1 flex-col">
+        <EmptyThreadState />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto">
+        {!loaded ? (
+          <MessageSkeletons />
+        ) : messages.length === 0 && !isRunning ? (
+          <ThreadEmptyState threadTitle={thread.title} />
+        ) : (
+          <div className="mx-auto max-w-[700px] space-y-4 px-5 py-5">
+            {messages.map((msg) => (
+              <MessageBubble key={msg.id} message={msg} />
+            ))}
+
+            {/* Streaming assistant message */}
+            {isRunning && streamingText !== null && (
+              <div className="flex gap-3">
+                <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A]">
+                  <span className="text-[9px] font-bold text-white">AI</span>
+                </div>
+                <div className="max-w-[78%]">
+                  <div className="rounded-[12px] rounded-tl-[4px] bg-[#F4F4F4] px-3.5 py-2.5 text-[13.5px] leading-[1.55] text-[#111111]">
+                    {streamingText || (
+                      <span className="flex items-center gap-1.5">
+                        <ThinkingDots />
+                      </span>
+                    )}
+                    {streamingText && (
+                      <>
+                        {" "}
+                        <span
+                          className="inline-block h-[13px] w-[2px] translate-y-[1px] rounded-full bg-[#555555] opacity-60"
+                          style={{ animation: "cursorBlink 900ms ease-in-out infinite" }}
+                        />
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Pending approvals */}
+            {pendingApprovals.map((approval) => (
+              <ApprovalCard
+                key={approval.id}
+                approval={approval}
+                onDecision={() => {
+                  setApprovals((prev) =>
+                    prev.map((a) =>
+                      a.id === approval.id ? { ...a, status: "approved" } : a,
+                    ),
+                  );
+                }}
+              />
+            ))}
+
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <AgentInput
+        onSubmit={handleSend}
+        disabled={isRunning}
+        placeholder={isRunning ? "Agent is working…" : "Message the agent…"}
+      />
+
+      <style>{`
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 0.6; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function ThinkingDots() {
+  return (
+    <span className="flex items-center gap-1">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="h-1.5 w-1.5 rounded-full bg-[#BBBBBB]"
+          style={{
+            animation: "dotPulse 1.2s ease-in-out infinite",
+            animationDelay: `${i * 200}ms`,
+          }}
+        />
+      ))}
+      <style>{`
+        @keyframes dotPulse {
+          0%, 80%, 100% { opacity: 0.3; transform: scale(0.85); }
+          40% { opacity: 1; transform: scale(1); }
+        }
+      `}</style>
+    </span>
+  );
+}
+
+function MessageSkeletons() {
+  return (
+    <div className="mx-auto max-w-[700px] space-y-4 px-5 py-5">
+      {[70, 55, 80].map((w, i) => (
+        <div key={i} className={`flex ${i % 2 === 0 ? "justify-end" : "justify-start"}`}>
+          <div
+            className="h-9 animate-pulse rounded-[12px] bg-[#F0F0F0]"
+            style={{ width: `${w}%` }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyThreadState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <p className="text-[13px] text-[#BBBBBB]">Select a conversation or start a new one.</p>
+    </div>
+  );
+}
+
+function ThreadEmptyState({ threadTitle }: { threadTitle: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+      <p className="text-[13.5px] font-medium text-[#333333]">{threadTitle}</p>
+      <p className="text-[12.5px] text-[#BBBBBB]">Send a message to get started.</p>
+    </div>
+  );
+}

--- a/fe+convex/components/agent/MessageBubble.tsx
+++ b/fe+convex/components/agent/MessageBubble.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Wrench } from "lucide-react";
+import type { AgentMessage, ContentBlock } from "./types";
+
+interface MessageBubbleProps {
+  message: AgentMessage;
+  streamingText?: string;
+}
+
+export function MessageBubble({ message, streamingText }: MessageBubbleProps) {
+  const isUser = message.role === "user";
+  const isTool = message.role === "tool";
+  const isStreaming = !!streamingText;
+
+  if (isTool) {
+    return <ToolResultRow message={message} />;
+  }
+
+  return (
+    <div className={`flex gap-3 ${isUser ? "justify-end" : "justify-start"}`}>
+      {!isUser && (
+        <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A]">
+          <span className="text-[9px] font-bold text-white">AI</span>
+        </div>
+      )}
+
+      <div className={`flex max-w-[78%] flex-col gap-1 ${isUser ? "items-end" : "items-start"}`}>
+        {message.content.map((block, i) => (
+          <ContentBlockView
+            key={i}
+            block={block}
+            isUser={isUser}
+            streamingText={i === message.content.length - 1 ? streamingText : undefined}
+          />
+        ))}
+
+        {isStreaming && message.content.length === 0 && (
+          <div className="rounded-[12px] rounded-tl-[4px] bg-[#F4F4F4] px-3.5 py-2.5">
+            <StreamingCursor />
+          </div>
+        )}
+      </div>
+
+      {isUser && (
+        <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-[#E0E0E0] bg-[#FFFFFF]">
+          <span className="text-[10px] font-semibold text-[#555555]">U</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ContentBlockView({
+  block,
+  isUser,
+  streamingText,
+}: {
+  block: ContentBlock;
+  isUser: boolean;
+  streamingText?: string;
+}) {
+  if (block.type === "text") {
+    const text = streamingText ?? block.text;
+    const isStreaming = !!streamingText;
+    return (
+      <div
+        className={`rounded-[12px] px-3.5 py-2.5 text-[13.5px] leading-[1.55] ${
+          isUser
+            ? "rounded-br-[4px] bg-[#0A0A0A] text-white"
+            : "rounded-tl-[4px] bg-[#F4F4F4] text-[#111111]"
+        }`}
+      >
+        {text}
+        {isStreaming && <StreamingCursor />}
+      </div>
+    );
+  }
+
+  if (block.type === "tool_use") {
+    return (
+      <div className="flex items-center gap-2 rounded-[8px] border border-[#EBEBEB] bg-[#FAFAFA] px-2.5 py-1.5">
+        <Wrench className="h-3 w-3 text-[#BBBBBB]" strokeWidth={1.8} />
+        <span className="font-mono text-[11px] text-[#555555]">{block.name}</span>
+        {block.input && (
+          <span className="text-[11px] text-[#BBBBBB]">
+            {JSON.stringify(block.input).slice(0, 48)}
+            {JSON.stringify(block.input).length > 48 ? "…" : ""}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function ToolResultRow({ message }: { message: AgentMessage }) {
+  const block = message.content[0];
+  if (!block || block.type !== "tool_result") return null;
+
+  return (
+    <div className="flex items-start gap-2 pl-9">
+      <div className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#CFCFCF]" />
+      <p className="text-[11.5px] text-[#999999]">{block.content}</p>
+    </div>
+  );
+}
+
+function StreamingCursor() {
+  return (
+    <>
+      {" "}
+      <span
+        className="inline-block h-[13px] w-[2px] translate-y-[1px] rounded-full bg-current opacity-60"
+        style={{ animation: "cursorBlink 900ms ease-in-out infinite" }}
+      />
+      <style>{`
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 0.6; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/fe+convex/components/agent/ThreadRail.tsx
+++ b/fe+convex/components/agent/ThreadRail.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MessageSquare, Plus, Zap } from "lucide-react";
+import type { AgentThread } from "./types";
+import { listThreads, createThread } from "./adapters/mock";
+
+interface ThreadRailProps {
+  activeThreadId: string | null;
+  onSelectThread: (thread: AgentThread) => void;
+  onNewThread: (thread: AgentThread) => void;
+}
+
+function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export function ThreadRail({ activeThreadId, onSelectThread, onNewThread }: ThreadRailProps) {
+  const [threads, setThreads] = useState<AgentThread[]>([]);
+  const [isCreating, setIsCreating] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    listThreads().then((data) => {
+      if (mounted.current) {
+        setThreads(data);
+        setLoaded(true);
+      }
+    });
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  async function handleNew() {
+    if (isCreating) return;
+    setIsCreating(true);
+    try {
+      const thread = await createThread();
+      setThreads((prev) => [thread, ...prev]);
+      onNewThread(thread);
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <aside
+      className="flex h-full w-60 flex-col border-r border-[#EBEBEB] bg-[#FAFAFA]"
+      style={{ minWidth: 0 }}
+    >
+      {/* Header */}
+      <div className="flex h-[60px] items-center justify-between border-b border-[#EBEBEB] px-4">
+        <div className="flex items-center gap-2">
+          <Zap className="h-4 w-4 text-[#0A0A0A]" strokeWidth={1.9} />
+          <span
+            className="text-[13px] font-semibold tracking-[-0.01em] text-[#111111]"
+            style={{ fontFamily: "var(--font-geist-sans)" }}
+          >
+            Agent
+          </span>
+        </div>
+        <button
+          onClick={handleNew}
+          disabled={isCreating}
+          className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#999999] transition-colors duration-150 hover:bg-[#EBEBEB] hover:text-[#0A0A0A] active:scale-95 disabled:opacity-40"
+          style={{ transition: "transform 120ms ease-out, background-color 120ms ease-out" }}
+          aria-label="New conversation"
+        >
+          <Plus className="h-4 w-4" strokeWidth={2} />
+        </button>
+      </div>
+
+      {/* Thread list */}
+      <div className="flex-1 overflow-y-auto py-2">
+        {!loaded ? (
+          <ThreadSkeletons />
+        ) : threads.length === 0 ? (
+          <EmptyState onNew={handleNew} />
+        ) : (
+          <ul className="space-y-px px-2">
+            {threads.map((thread, i) => {
+              const active = thread.id === activeThreadId;
+              return (
+                <li
+                  key={thread.id}
+                  style={{
+                    animationDelay: `${i * 40}ms`,
+                    animationFillMode: "both",
+                  }}
+                  className="thread-item-enter"
+                >
+                  <button
+                    onClick={() => onSelectThread(thread)}
+                    className={`group w-full rounded-[8px] px-3 py-2.5 text-left transition-colors duration-100 ${
+                      active
+                        ? "border border-[#CFCFCF] bg-[#EAEAEA]"
+                        : "border border-transparent hover:bg-[#EFEFEF]"
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <MessageSquare
+                        className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
+                          active ? "text-[#0A0A0A]" : "text-[#BBBBBB]"
+                        }`}
+                        strokeWidth={1.8}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className={`truncate text-[12.5px] font-medium leading-snug ${
+                            active ? "text-[#0A0A0A]" : "text-[#333333]"
+                          }`}
+                        >
+                          {thread.title}
+                        </p>
+                        {thread.lastMessage ? (
+                          <p className="mt-0.5 truncate text-[11.5px] text-[#999999]">
+                            {thread.lastMessage}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <p className="mt-1.5 pl-5 text-[10.5px] text-[#BBBBBB]">
+                      {timeAgo(thread.lastActivityAt)}
+                    </p>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes threadItemIn {
+          from { opacity: 0; transform: translateY(4px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .thread-item-enter {
+          animation: threadItemIn 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
+        }
+      `}</style>
+    </aside>
+  );
+}
+
+function ThreadSkeletons() {
+  return (
+    <div className="space-y-px px-2 py-1">
+      {[80, 65, 72].map((w, i) => (
+        <div key={i} className="rounded-[8px] px-3 py-2.5">
+          <div className="h-2.5 w-3/4 animate-pulse rounded-full bg-[#E8E8E8]" />
+          <div
+            className="mt-1.5 animate-pulse rounded-full bg-[#EFEFEF]"
+            style={{ height: 9, width: `${w}%` }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="px-4 py-8 text-center">
+      <p className="text-[12px] text-[#BBBBBB]">No conversations yet.</p>
+      <button
+        onClick={onNew}
+        className="mt-3 text-[12px] font-medium text-[#555555] underline-offset-2 hover:underline"
+      >
+        Start one
+      </button>
+    </div>
+  );
+}

--- a/fe+convex/components/agent/adapters/mock.ts
+++ b/fe+convex/components/agent/adapters/mock.ts
@@ -1,0 +1,293 @@
+/**
+ * Mock adapter for the agent workspace.
+ *
+ * This module stands in for real Modal + Convex endpoints while backend
+ * contracts are being finalized. Replace the functions here with real API
+ * calls once the Modal runtime and Convex persistence layers are ready.
+ *
+ * Contract surface this adapter must match:
+ *   POST /agent/threads      → createThread()
+ *   GET  /agent/threads      → listThreads()
+ *   GET  /agent/threads/:id  → getThreadState()
+ *   POST /agent/runs         → startRun()
+ *   POST /agent/approvals/:id → submitApproval()
+ */
+
+import type {
+  AgentThread,
+  AgentMessage,
+  AgentArtifact,
+  AgentApproval,
+  AgentRun,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// Seed data
+// ---------------------------------------------------------------------------
+
+const THREADS: AgentThread[] = [
+  {
+    id: "thread-1",
+    title: "Spring 2025 speaker outreach",
+    channel: "web",
+    lastMessage: "I found 8 candidates matching the target profile.",
+    lastActivityAt: Date.now() - 1000 * 60 * 12,
+    contextLinks: [{ type: "event", id: "evt-01", label: "Spring 2025" }],
+  },
+  {
+    id: "thread-2",
+    title: "Room availability check",
+    channel: "web",
+    lastMessage: "Staller 104 is open on April 18th.",
+    lastActivityAt: Date.now() - 1000 * 60 * 60 * 2,
+  },
+  {
+    id: "thread-3",
+    title: "Communications review",
+    channel: "discord",
+    lastMessage: "Draft email ready for your review.",
+    lastActivityAt: Date.now() - 1000 * 60 * 60 * 24,
+  },
+];
+
+const MESSAGES: Record<string, AgentMessage[]> = {
+  "thread-1": [
+    {
+      id: "msg-1a",
+      threadId: "thread-1",
+      role: "user",
+      content: [{ type: "text", text: "Find speakers for the Spring 2025 event." }],
+      createdAt: Date.now() - 1000 * 60 * 15,
+    },
+    {
+      id: "msg-1b",
+      threadId: "thread-1",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: "attio_search_speakers",
+          input: { status: "Prospect", limit: 20 },
+        },
+      ],
+      createdAt: Date.now() - 1000 * 60 * 14,
+    },
+    {
+      id: "msg-1c",
+      threadId: "thread-1",
+      role: "tool",
+      content: [{ type: "tool_result", content: "Found 8 candidates." }],
+      createdAt: Date.now() - 1000 * 60 * 14,
+    },
+    {
+      id: "msg-1d",
+      threadId: "thread-1",
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "I found 8 candidates matching the target profile for Spring 2025. I've compiled their details into a table below. Three are strong fits based on previous engagement — I'd suggest starting outreach with those.",
+        },
+      ],
+      artifactIds: ["artifact-1"],
+      createdAt: Date.now() - 1000 * 60 * 12,
+    },
+  ],
+  "thread-2": [
+    {
+      id: "msg-2a",
+      threadId: "thread-2",
+      role: "user",
+      content: [{ type: "text", text: "Is Staller 104 available on April 18th?" }],
+      createdAt: Date.now() - 1000 * 60 * 60 * 2 - 2000,
+    },
+    {
+      id: "msg-2b",
+      threadId: "thread-2",
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Staller 104 is open on April 18th from 6:00 PM to 9:00 PM. Would you like me to prepare a room booking request?",
+        },
+      ],
+      createdAt: Date.now() - 1000 * 60 * 60 * 2,
+    },
+  ],
+  "thread-3": [
+    {
+      id: "msg-3a",
+      threadId: "thread-3",
+      role: "user",
+      content: [{ type: "text", text: "Draft an outreach email for the shortlisted speakers." }],
+      createdAt: Date.now() - 1000 * 60 * 60 * 24 - 5000,
+    },
+    {
+      id: "msg-3b",
+      threadId: "thread-3",
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Draft email ready. Subject: "Speaking Opportunity — Spring 2025 Tech Event". Should I send it to the 3 shortlisted speakers, or would you like to review first?',
+        },
+      ],
+      createdAt: Date.now() - 1000 * 60 * 60 * 24,
+    },
+  ],
+};
+
+const ARTIFACTS: Record<string, AgentArtifact> = {
+  "artifact-1": {
+    id: "artifact-1",
+    threadId: "thread-1",
+    type: "table",
+    title: "Speaker Candidates — Spring 2025",
+    data: {
+      columns: ["Name", "Title", "Status", "Fit"],
+      rows: [
+        ["Priya Anand", "Staff Eng, Stripe", "Prospect", "High"],
+        ["Marcus Osei", "PM, Linear", "Engaged", "High"],
+        ["Sara Kim", "Founder, Daylight", "Prospect", "High"],
+        ["James Park", "EM, Vercel", "Prospect", "Medium"],
+        ["Leila Nouri", "Designer, Figma", "Declined", "Low"],
+        ["Tom Walsh", "CTO, Interval", "Prospect", "Medium"],
+        ["Ana Carvalho", "Eng, Clerk", "Prospect", "Medium"],
+        ["Dev Patel", "Staff Eng, Retool", "Prospect", "Low"],
+      ],
+    },
+    createdAt: Date.now() - 1000 * 60 * 12,
+  },
+};
+
+const APPROVALS: Record<string, AgentApproval[]> = {
+  "thread-3": [
+    {
+      id: "approval-1",
+      threadId: "thread-3",
+      runId: "run-3",
+      requestedAction: "Send outreach emails to 3 speakers",
+      riskLevel: "medium",
+      proposedPayload: {
+        recipients: ["Priya Anand", "Marcus Osei", "Sara Kim"],
+        subject: "Speaking Opportunity — Spring 2025 Tech Event",
+        templateId: "outreach-v2",
+      },
+      status: "pending",
+      createdAt: Date.now() - 1000 * 60 * 60 * 24 + 1000,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Adapter functions  (replace with real API calls)
+// ---------------------------------------------------------------------------
+
+export async function listThreads(): Promise<AgentThread[]> {
+  await delay(120);
+  return [...THREADS];
+}
+
+export async function getThreadMessages(threadId: string): Promise<AgentMessage[]> {
+  await delay(80);
+  return MESSAGES[threadId] ?? [];
+}
+
+export async function getThreadArtifacts(threadId: string): Promise<AgentArtifact[]> {
+  await delay(60);
+  const thread = THREADS.find((t) => t.id === threadId);
+  if (!thread) return [];
+  const msgs = MESSAGES[threadId] ?? [];
+  const artifactIds = msgs.flatMap((m) => m.artifactIds ?? []);
+  return artifactIds.map((id) => ARTIFACTS[id]).filter(Boolean) as AgentArtifact[];
+}
+
+export async function getThreadApprovals(threadId: string): Promise<AgentApproval[]> {
+  await delay(60);
+  return APPROVALS[threadId] ?? [];
+}
+
+export async function createThread(title?: string): Promise<AgentThread> {
+  await delay(200);
+  const thread: AgentThread = {
+    id: `thread-${Date.now()}`,
+    title: title ?? "New conversation",
+    channel: "web",
+    lastActivityAt: Date.now(),
+  };
+  THREADS.unshift(thread);
+  MESSAGES[thread.id] = [];
+  return thread;
+}
+
+/**
+ * Simulates streaming a modal run response by calling onChunk incrementally.
+ * Replace with SSE from GET /agent/runs/:id/stream.
+ */
+export async function startRun(
+  threadId: string,
+  userMessage: string,
+  onChunk: (text: string) => void,
+  onDone: (message: AgentMessage) => void,
+): Promise<void> {
+  const userMsg: AgentMessage = {
+    id: `msg-${Date.now()}-user`,
+    threadId,
+    role: "user",
+    content: [{ type: "text", text: userMessage }],
+    createdAt: Date.now(),
+  };
+  if (!MESSAGES[threadId]) MESSAGES[threadId] = [];
+  MESSAGES[threadId].push(userMsg);
+
+  await delay(400);
+
+  const reply =
+    "I'm processing your request. This is a mocked response — the real Modal runtime will replace this with streamed agent output once the backend contracts are ready.";
+
+  let accumulated = "";
+  for (const char of reply) {
+    accumulated += char;
+    onChunk(accumulated);
+    await delay(18);
+  }
+
+  const assistantMsg: AgentMessage = {
+    id: `msg-${Date.now()}-assistant`,
+    threadId,
+    role: "assistant",
+    content: [{ type: "text", text: reply }],
+    createdAt: Date.now(),
+  };
+  MESSAGES[threadId].push(assistantMsg);
+
+  const thread = THREADS.find((t) => t.id === threadId);
+  if (thread) {
+    thread.lastMessage = reply.slice(0, 80);
+    thread.lastActivityAt = Date.now();
+  }
+
+  onDone(assistantMsg);
+}
+
+export async function submitApproval(
+  approvalId: string,
+  decision: "approved" | "rejected",
+): Promise<void> {
+  await delay(300);
+  for (const approvals of Object.values(APPROVALS)) {
+    const approval = approvals.find((a) => a.id === approvalId);
+    if (approval) {
+      approval.status = decision;
+      return;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function delay(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}

--- a/fe+convex/components/agent/types.ts
+++ b/fe+convex/components/agent/types.ts
@@ -1,0 +1,110 @@
+export type MessageRole = "user" | "assistant" | "tool";
+export type RunStatus = "idle" | "running" | "paused_approval" | "completed" | "error";
+export type ArtifactType =
+  | "metric_group"
+  | "table"
+  | "timeline"
+  | "checklist"
+  | "report"
+  | "chart"
+  | "link_bundle";
+export type RiskLevel = "low" | "medium" | "high";
+
+export interface AgentThread {
+  id: string;
+  title: string;
+  channel: "web" | "discord";
+  lastMessage?: string;
+  lastActivityAt: number;
+  contextLinks?: ContextLink[];
+}
+
+export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+export interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface ToolUseBlock {
+  type: "tool_use";
+  name: string;
+  input?: Record<string, unknown>;
+}
+
+export interface ToolResultBlock {
+  type: "tool_result";
+  content: string;
+}
+
+export interface AgentMessage {
+  id: string;
+  threadId: string;
+  role: MessageRole;
+  content: ContentBlock[];
+  artifactIds?: string[];
+  createdAt: number;
+  isStreaming?: boolean;
+}
+
+export interface MetricItem {
+  label: string;
+  value: string | number;
+  delta?: string;
+  deltaDirection?: "up" | "down" | "neutral";
+}
+
+export interface MetricGroupData {
+  metrics: MetricItem[];
+}
+
+export interface TableData {
+  columns: string[];
+  rows: (string | number | null)[][];
+}
+
+export interface ChecklistItem {
+  id: string;
+  label: string;
+  checked: boolean;
+  notes?: string;
+}
+
+export interface ChecklistData {
+  items: ChecklistItem[];
+}
+
+export interface AgentArtifact {
+  id: string;
+  threadId: string;
+  type: ArtifactType;
+  title: string;
+  data: MetricGroupData | TableData | ChecklistData | Record<string, unknown>;
+  createdAt: number;
+}
+
+export interface AgentApproval {
+  id: string;
+  threadId: string;
+  runId: string;
+  requestedAction: string;
+  riskLevel: RiskLevel;
+  proposedPayload: Record<string, unknown>;
+  status: "pending" | "approved" | "rejected";
+  createdAt: number;
+}
+
+export interface ContextLink {
+  type: "event" | "speaker" | "person" | "communication";
+  id: string;
+  label: string;
+}
+
+export interface AgentRun {
+  id: string;
+  threadId: string;
+  status: RunStatus;
+  currentStep?: string;
+  startedAt: number;
+  finishedAt?: number;
+}

--- a/fe+convex/middleware.ts
+++ b/fe+convex/middleware.ts
@@ -11,20 +11,18 @@ export async function middleware(request: NextRequest) {
   const session = getSessionCookie(request);
   const { pathname, search } = request.nextUrl;
   const isDashboardRoute = pathname.startsWith("/dashboard");
+  const isAgentRoute = pathname === "/agent" || pathname.startsWith("/agent/");
   const isAuthRoute = pathname === "/login" || pathname === "/signup";
 
-  if (!session && isDashboardRoute) {
+  if (!session && (isDashboardRoute || isAgentRoute)) {
     const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set(
-      "redirect",
-      `${pathname}${search}`
-    );
+    loginUrl.searchParams.set("redirect", `${pathname}${search}`);
     return NextResponse.redirect(loginUrl);
   }
 
   if (session && isAuthRoute) {
     const safeRedirect =
-      getSafeRedirectPath(request.nextUrl.searchParams.get("redirect")) ?? "/dashboard";
+      getSafeRedirectPath(request.nextUrl.searchParams.get("redirect")) ?? "/agent";
     return NextResponse.redirect(new URL(safeRedirect, request.url));
   }
 
@@ -32,5 +30,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/login", "/signup"],
+  matcher: ["/dashboard/:path*", "/agent", "/agent/:path*", "/login", "/signup"],
 };


### PR DESCRIPTION
Builds the authenticated `/agent` workspace as the primary landing route for signed-in users. The UI is a three-panel shell: a thread rail (left, 240px), a streaming conversation timeline (center), and a collapsible artifact canvas (right, 320px). Includes inline approval cards with approve/reject flow, artifact renderers for `table`, `metric_group`, and `checklist` types, and a clean mock adapter boundary (`components/agent/adapters/mock.ts`) that stands in for Modal and Convex endpoints until backend contracts are ready. Middleware is updated to protect `/agent` and redirect post-auth users to `/agent` instead of `/dashboard`; the dashboard sidebar gains an Agent nav link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)