### PR TITLE
Add Modal conversational runtime and MCP IO tests

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -6,6 +6,7 @@ Modal-based serverless agents for the event organizer pipeline.
 
 | File | Modal App Name | Purpose |
 |------|---------------|---------|
+| `runtime/modal_app.py` | `event-agent-runtime` | Shared conversational runtime (`/agent/threads`, `/agent/runs`, `/agent/approvals`) |
 | `match.py` | `event-matching` | Phase 2 — score and rank speaker candidates from Attio |
 | `outreach.py` | `event-outreach` | Phase 3 — send outreach emails via AgentMail |
 | `reply_handler.py` | `event-outreach-replies` | Phase 4 — webhook endpoint, classifies inbound emails and updates Convex + Attio |
@@ -19,6 +20,9 @@ bash tests/run_tests.sh
 
 # or directly with pytest
 doppler run -- python -m pytest tests/ -v
+
+# runtime-only tests
+python -m pytest tests/test_runtime_*.py -v
 ```
 
 ## Helper Modules (`helper/`)

--- a/agent/runtime/__init__.py
+++ b/agent/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Shared conversational runtime modules for Modal-hosted agent endpoints."""

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import anthropic
+
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are the Event Organizer runtime assistant. "
+    "Respond with concise operational guidance and clear next actions."
+)
+
+
+class AnthropicRuntimeAdapter:
+    """
+    Local adapter boundary around Anthropic usage.
+
+    The rest of the application depends on this adapter only, so SDK/harness
+    implementation details stay isolated to one module.
+    """
+
+    def __init__(self, *, model: str | None = None) -> None:
+        self._api_key = os.environ.get("ANTHROPIC_API_KEY")
+        self._model = model or os.environ.get("ANTHROPIC_MODEL", "claude-3-5-haiku-latest")
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        if not self._api_key:
+            fallback = (
+                "Anthropic API key is not configured. "
+                "This run used the local fallback adapter response."
+            )
+            for chunk in _chunk_text(fallback):
+                yield chunk
+            return
+
+        client = anthropic.AsyncAnthropic(api_key=self._api_key)
+        msg = await client.messages.create(
+            model=self._model,
+            max_tokens=max_tokens,
+            system=system_prompt or DEFAULT_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        text = "".join(
+            block.text for block in msg.content if getattr(block, "type", None) == "text"
+        ).strip()
+        if not text:
+            text = "I finished the run but produced no text output."
+
+        for chunk in _chunk_text(text):
+            yield chunk
+
+
+def _chunk_text(text: str, words_per_chunk: int = 12) -> list[str]:
+    words = text.split()
+    if not words:
+        return []
+
+    chunks: list[str] = []
+    for i in range(0, len(words), words_per_chunk):
+        chunk = " ".join(words[: i + words_per_chunk])
+        chunks.append(chunk)
+    return chunks

--- a/agent/runtime/api.py
+++ b/agent/runtime/api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI, Query
+from fastapi.responses import StreamingResponse
+
+from runtime.contracts import (
+    ApprovalDecisionRequest,
+    ApprovalDecisionResponse,
+    RunCreateRequest,
+    RunRecord,
+    ThreadCreateRequest,
+    ThreadRecord,
+    ThreadStateResponse,
+)
+from runtime.normalize import as_sse
+from runtime.service import AgentRuntimeService
+
+
+def build_app(service: AgentRuntimeService | None = None) -> FastAPI:
+    runtime = service or AgentRuntimeService()
+
+    app = FastAPI(
+        title="Event Organizer Agent Runtime",
+        version="0.1.0",
+        description="Canonical Modal-hosted conversational runtime endpoints.",
+    )
+
+    @app.post("/agent/threads", response_model=ThreadRecord)
+    async def create_thread(payload: ThreadCreateRequest) -> ThreadRecord:
+        return await runtime.create_thread(payload)
+
+    @app.get("/agent/threads/{thread_id}", response_model=ThreadStateResponse)
+    async def get_thread(thread_id: str) -> ThreadStateResponse:
+        return await runtime.get_thread_state(thread_id)
+
+    @app.post("/agent/runs", response_model=RunRecord)
+    async def start_run(payload: RunCreateRequest) -> RunRecord:
+        return await runtime.start_run(payload)
+
+    @app.get("/agent/runs/{run_id}/stream")
+    async def stream_run(
+        run_id: str,
+        after_sequence: int = Query(default=0, ge=0),
+    ) -> StreamingResponse:
+        async def event_source() -> AsyncIterator[str]:
+            events = await runtime.list_run_events(run_id, after_sequence=after_sequence)
+            for event in events:
+                yield as_sse(event)
+
+        return StreamingResponse(event_source(), media_type="text/event-stream")
+
+    @app.post("/agent/approvals/{approval_id}", response_model=ApprovalDecisionResponse)
+    async def submit_approval(approval_id: str, payload: ApprovalDecisionRequest) -> ApprovalDecisionResponse:
+        return await runtime.submit_approval(approval_id, payload)
+
+    return app

--- a/agent/runtime/contracts.py
+++ b/agent/runtime/contracts.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Channel(str, Enum):
+    WEB = "web"
+    DISCORD = "discord"
+
+
+class RunStatus(str, Enum):
+    IDLE = "idle"
+    RUNNING = "running"
+    PAUSED_APPROVAL = "paused_approval"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+class RiskLevel(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class ApprovalStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class ArtifactKind(str, Enum):
+    METRIC_GROUP = "metric_group"
+    TABLE = "table"
+    TIMELINE = "timeline"
+    CHECKLIST = "checklist"
+    REPORT = "report"
+    CHART = "chart"
+    LINK_BUNDLE = "link_bundle"
+
+
+class ContentBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    label: str | None = None
+    text: str | None = None
+    mime_type: str | None = None
+    data_json: str | None = None
+    url: str | None = None
+
+
+class ContextLinkRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    link_key: str
+    relation: str
+    entity_type: str
+    entity_id: str
+    label: str | None = None
+    url: str | None = None
+    metadata_json: str | None = None
+    created_at: int
+    updated_at: int
+
+
+class ContextLinkInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    relation: str = "context"
+    entity_type: str
+    entity_id: str
+    label: str | None = None
+    url: str | None = None
+    metadata_json: str | None = None
+
+
+class ThreadRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    channel: Channel
+    status: str = "active"
+    title: str | None = None
+    summary: str | None = None
+    created_by_user_id: str | None = None
+    last_message_at: int | None = None
+    last_run_started_at: int | None = None
+    archived_at: int | None = None
+    created_at: int
+    updated_at: int
+
+
+class RunRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    status: RunStatus
+    trigger_source: str
+    mode: str | None = None
+    initiated_by_user_id: str | None = None
+    model: str | None = None
+    summary: str | None = None
+    error_message: str | None = None
+    started_at: int
+    completed_at: int | None = None
+    updated_at: int
+    latest_message_sequence: int | None = None
+
+
+class MessageRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    run_external_id: str | None = None
+    role: str
+    status: str
+    sequence_number: int
+    plain_text: str | None = None
+    content_blocks: list[ContentBlock]
+    created_at: int
+    updated_at: int
+
+
+class ArtifactRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    run_external_id: str | None = None
+    kind: ArtifactKind
+    status: str
+    sort_order: int
+    title: str | None = None
+    summary: str | None = None
+    content_blocks: list[ContentBlock]
+    created_at: int
+    updated_at: int
+
+
+class ApprovalRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    run_external_id: str
+    status: ApprovalStatus
+    action_type: str
+    title: str
+    summary: str | None = None
+    risk_level: RiskLevel
+    payload_json: str | None = None
+    requested_at: int
+    expires_at: int | None = None
+    resolved_at: int | None = None
+    decision_note: str | None = None
+    decided_by_user_id: str | None = None
+    updated_at: int
+
+
+class StreamEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    sequence: int
+    event: str
+    created_at: int
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ThreadCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str | None = None
+    channel: Channel = Channel.WEB
+    title: str | None = None
+    created_by_user_id: str | None = None
+    context_links: list[ContextLinkInput] | None = None
+
+
+class RunCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    thread_id: str
+    input_text: str
+    trigger_source: str = "web"
+    mode: str | None = None
+    initiated_by_user_id: str | None = None
+    max_tokens: int = 900
+
+
+class ApprovalDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["approved", "rejected"]
+    note: str | None = None
+    decided_by_user_id: str | None = None
+
+
+class ThreadStateResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    thread: ThreadRecord
+    runs: list[RunRecord]
+    messages: list[MessageRecord]
+    artifacts: list[ArtifactRecord]
+    approvals: list[ApprovalRecord]
+    context_links: list[ContextLinkRecord]
+
+
+class ApprovalDecisionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    approval: ApprovalRecord
+    run: RunRecord

--- a/agent/runtime/convex_sync.py
+++ b/agent/runtime/convex_sync.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from helper.tools import ConvexClient
+from runtime.contracts import (
+    ApprovalRecord,
+    ArtifactRecord,
+    ContextLinkRecord,
+    MessageRecord,
+    RunRecord,
+    ThreadRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ConvexAgentStateSync:
+    """Best-effort Convex synchronization for normalized agent state."""
+
+    def __init__(self) -> None:
+        self._enabled = bool(os.environ.get("CONVEX_URL") and os.environ.get("CONVEX_DEPLOY_KEY"))
+        self._thread_id_map: dict[str, str] = {}
+        self._run_id_map: dict[str, str] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def upsert_thread(self, record: ThreadRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        args = {
+            "external_id": record.external_id,
+            "channel": record.channel.value,
+            "status": record.status,
+            "title": record.title,
+            "summary": record.summary,
+            "created_by_user_id": record.created_by_user_id,
+            "last_message_at": record.last_message_at,
+            "last_run_started_at": record.last_run_started_at,
+            "archived_at": record.archived_at,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                convex_id = await sb.mutation("agentState:upsertThread", args)
+            if isinstance(convex_id, str):
+                self._thread_id_map[record.external_id] = convex_id
+            return convex_id
+        except Exception as exc:
+            logger.warning("Convex thread sync failed: %s", exc)
+            return None
+
+    async def upsert_run(self, record: RunRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        if not thread_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "external_id": record.external_id,
+            "status": record.status.value,
+            "trigger_source": record.trigger_source,
+            "mode": record.mode,
+            "initiated_by_user_id": record.initiated_by_user_id,
+            "model": record.model,
+            "summary": record.summary,
+            "error_message": record.error_message,
+            "started_at": record.started_at,
+            "completed_at": record.completed_at,
+            "updated_at": record.updated_at,
+            "latest_message_sequence": record.latest_message_sequence,
+        }
+        try:
+            async with ConvexClient() as sb:
+                convex_id = await sb.mutation("agentState:upsertRun", args)
+            if isinstance(convex_id, str):
+                self._run_id_map[record.external_id] = convex_id
+            return convex_id
+        except Exception as exc:
+            logger.warning("Convex run sync failed: %s", exc)
+            return None
+
+    async def append_message(self, record: MessageRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        run_convex_id = await self._ensure_run_convex_id(record.run_external_id) if record.run_external_id else None
+        if not thread_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "run_id": run_convex_id,
+            "external_id": record.external_id,
+            "role": record.role,
+            "status": record.status,
+            "sequence_number": record.sequence_number,
+            "plain_text": record.plain_text,
+            "content_blocks": [block.model_dump() for block in record.content_blocks],
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:appendMessage", args)
+        except Exception as exc:
+            logger.warning("Convex message sync failed: %s", exc)
+            return None
+
+    async def upsert_artifact(self, record: ArtifactRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        run_convex_id = await self._ensure_run_convex_id(record.run_external_id) if record.run_external_id else None
+        if not thread_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "run_id": run_convex_id,
+            "external_id": record.external_id,
+            "kind": record.kind.value,
+            "status": record.status,
+            "sort_order": record.sort_order,
+            "title": record.title,
+            "summary": record.summary,
+            "content_blocks": [block.model_dump() for block in record.content_blocks],
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:upsertArtifact", args)
+        except Exception as exc:
+            logger.warning("Convex artifact sync failed: %s", exc)
+            return None
+
+    async def upsert_approval(self, record: ApprovalRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        run_convex_id = await self._ensure_run_convex_id(record.run_external_id)
+        if not thread_convex_id or not run_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "run_id": run_convex_id,
+            "external_id": record.external_id,
+            "status": record.status.value,
+            "action_type": record.action_type,
+            "title": record.title,
+            "summary": record.summary,
+            "risk_level": record.risk_level.value,
+            "payload_json": record.payload_json,
+            "requested_at": record.requested_at,
+            "expires_at": record.expires_at,
+            "resolved_at": record.resolved_at,
+            "decision_note": record.decision_note,
+            "decided_by_user_id": record.decided_by_user_id,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:upsertApproval", args)
+        except Exception as exc:
+            logger.warning("Convex approval sync failed: %s", exc)
+            return None
+
+    async def resolve_approval(self, record: ApprovalRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        args = {
+            "external_id": record.external_id,
+            "status": record.status.value,
+            "decision_note": record.decision_note,
+            "decided_by_user_id": record.decided_by_user_id,
+            "resolved_at": record.resolved_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:resolveApproval", args)
+        except Exception as exc:
+            logger.warning("Convex approval resolve sync failed: %s", exc)
+            return None
+
+    async def upsert_context_link(self, thread_external_id: str, record: ContextLinkRecord, run_external_id: str | None = None) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(thread_external_id)
+        run_convex_id = await self._ensure_run_convex_id(run_external_id) if run_external_id else None
+        if not thread_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "run_id": run_convex_id,
+            "link_key": record.link_key,
+            "relation": record.relation,
+            "entity_type": record.entity_type,
+            "entity_id": record.entity_id,
+            "label": record.label,
+            "url": record.url,
+            "metadata_json": record.metadata_json,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:upsertContextLink", args)
+        except Exception as exc:
+            logger.warning("Convex context-link sync failed: %s", exc)
+            return None
+
+    async def fetch_thread_state(self, external_thread_id: str) -> dict | None:
+        if not self._enabled:
+            return None
+        try:
+            async with ConvexClient() as sb:
+                return await sb.query("agentState:getThreadState", {"external_id": external_thread_id})
+        except Exception as exc:
+            logger.warning("Convex thread fetch failed: %s", exc)
+            return None
+
+    async def _ensure_thread_convex_id(self, external_thread_id: str) -> str | None:
+        cached = self._thread_id_map.get(external_thread_id)
+        if cached:
+            return cached
+
+        state = await self.fetch_thread_state(external_thread_id)
+        thread = (state or {}).get("thread") if isinstance(state, dict) else None
+        if isinstance(thread, dict):
+            thread_id = thread.get("_id")
+            if isinstance(thread_id, str):
+                self._thread_id_map[external_thread_id] = thread_id
+                return thread_id
+        return None
+
+    async def _ensure_run_convex_id(self, external_run_id: str | None) -> str | None:
+        if not external_run_id:
+            return None
+        cached = self._run_id_map.get(external_run_id)
+        if cached:
+            return cached
+
+        try:
+            async with ConvexClient() as sb:
+                state = await sb.query("agentState:getRunState", {"external_id": external_run_id})
+        except Exception as exc:
+            logger.warning("Convex run fetch failed: %s", exc)
+            return None
+
+        run = (state or {}).get("run") if isinstance(state, dict) else None
+        if isinstance(run, dict):
+            run_id = run.get("_id")
+            if isinstance(run_id, str):
+                self._run_id_map[external_run_id] = run_id
+                return run_id
+        return None

--- a/agent/runtime/modal_app.py
+++ b/agent/runtime/modal_app.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import modal
+
+app = modal.App("event-agent-runtime")
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("httpx>=0.27", "anthropic>=0.40", "python-dotenv", "pydantic[email]>=2.0", "modal", "fastapi[standard]")
+    .add_local_python_source("helper", "runtime")
+)
+
+
+@app.function(
+    image=image,
+    secrets=[modal.Secret.from_name("event-outreach-secrets")],
+    timeout=600,
+)
+@modal.asgi_app()
+def fastapi_app():
+    from runtime.api import build_app
+
+    return build_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    from runtime.api import build_app
+
+    uvicorn.run(build_app(), host="127.0.0.1", port=8000)

--- a/agent/runtime/normalize.py
+++ b/agent/runtime/normalize.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from runtime.contracts import ArtifactKind, ArtifactRecord, ContentBlock, StreamEvent
+
+
+def now_ms() -> int:
+    from time import time
+
+    return int(time() * 1000)
+
+
+def text_block(text: str, *, label: str | None = None) -> ContentBlock:
+    return ContentBlock(kind="text", label=label, text=text)
+
+
+def json_block(kind: str, payload: dict, *, label: str | None = None) -> ContentBlock:
+    return ContentBlock(kind=kind, label=label, mime_type="application/json", data_json=json.dumps(payload))
+
+
+def plain_text_from_blocks(blocks: Iterable[ContentBlock]) -> str:
+    parts = [block.text for block in blocks if block.text]
+    return "\n".join(parts).strip()
+
+
+def make_report_artifact(
+    *,
+    external_id: str,
+    thread_id: str,
+    run_id: str,
+    title: str,
+    summary: str,
+    report_text: str,
+    sort_order: int,
+) -> ArtifactRecord:
+    created_at = now_ms()
+    return ArtifactRecord(
+        external_id=external_id,
+        thread_external_id=thread_id,
+        run_external_id=run_id,
+        kind=ArtifactKind.REPORT,
+        status="ready",
+        sort_order=sort_order,
+        title=title,
+        summary=summary,
+        content_blocks=[
+            text_block(report_text, label="body"),
+            json_block("report_meta", {"source": "modal_runtime"}, label="meta"),
+        ],
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def as_sse(event: StreamEvent) -> str:
+    payload = event.model_dump_json()
+    return f"event: {event.event}\ndata: {payload}\n\n"

--- a/agent/runtime/policy.py
+++ b/agent/runtime/policy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from runtime.contracts import RiskLevel
+
+
+class ActionClass(str, Enum):
+    READ = "read"
+    ANALYZE = "analyze"
+    FETCH = "fetch"
+    WRITE = "write"
+    SEND = "send"
+    DESTRUCTIVE = "destructive"
+
+
+class ToolAction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    action_class: ActionClass
+    payload: dict = Field(default_factory=dict)
+
+
+class PolicyDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    requires_approval: bool
+    risk_level: RiskLevel
+    reason: str
+
+
+class ApprovalPolicy:
+    """Central policy guard for tool and side-effect approvals."""
+
+    def evaluate(self, action: ToolAction) -> PolicyDecision:
+        if action.action_class == ActionClass.DESTRUCTIVE:
+            return PolicyDecision(
+                requires_approval=True,
+                risk_level=RiskLevel.HIGH,
+                reason="Destructive action requires explicit approval.",
+            )
+        if action.action_class in {ActionClass.WRITE, ActionClass.SEND}:
+            return PolicyDecision(
+                requires_approval=True,
+                risk_level=RiskLevel.MEDIUM,
+                reason="Write or externally visible action requires approval.",
+            )
+        return PolicyDecision(
+            requires_approval=False,
+            risk_level=RiskLevel.LOW,
+            reason="Read/analyze/fetch action can execute without approval.",
+        )
+
+
+def infer_tool_action_from_text(text: str) -> ToolAction | None:
+    """
+    Lightweight heuristic to classify intended action type.
+
+    This keeps policy decisions Modal-side while Anthropic remains a harness adapter.
+    """
+    lowered = text.lower().strip()
+    if not lowered:
+        return None
+
+    if any(token in lowered for token in ("delete", "remove", "purge", "wipe", "destroy")):
+        return ToolAction(name="destructive_change", action_class=ActionClass.DESTRUCTIVE)
+
+    if any(token in lowered for token in ("send", "email", "message", "invite", "outreach")):
+        return ToolAction(name="outbound_send", action_class=ActionClass.SEND)
+
+    if any(token in lowered for token in ("update", "create", "set ", "assign", "write", "change")):
+        return ToolAction(name="state_write", action_class=ActionClass.WRITE)
+
+    if any(token in lowered for token in ("analyze", "summarize", "explain", "compare")):
+        return ToolAction(name="analysis", action_class=ActionClass.ANALYZE)
+
+    if any(token in lowered for token in ("find", "search", "list", "show", "fetch", "read")):
+        return ToolAction(name="data_lookup", action_class=ActionClass.READ)
+
+    return None

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import json
+from time import time
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from runtime.anthropic_adapter import AnthropicRuntimeAdapter
+from runtime.contracts import (
+    ApprovalDecisionRequest,
+    ApprovalDecisionResponse,
+    ApprovalRecord,
+    ApprovalStatus,
+    ArtifactRecord,
+    ContextLinkRecord,
+    MessageRecord,
+    RunCreateRequest,
+    RunRecord,
+    RunStatus,
+    ThreadCreateRequest,
+    ThreadRecord,
+    ThreadStateResponse,
+)
+from runtime.convex_sync import ConvexAgentStateSync
+from runtime.normalize import make_report_artifact, text_block
+from runtime.policy import ApprovalPolicy, ToolAction, infer_tool_action_from_text
+from runtime.store import InMemoryRuntimeStore
+
+
+def _now_ms() -> int:
+    return int(time() * 1000)
+
+
+class AgentRuntimeService:
+    """Modal-side orchestration service for threads, runs, approvals, and sync."""
+
+    def __init__(
+        self,
+        *,
+        store: InMemoryRuntimeStore | None = None,
+        adapter: AnthropicRuntimeAdapter | None = None,
+        policy: ApprovalPolicy | None = None,
+        convex_sync: ConvexAgentStateSync | None = None,
+    ) -> None:
+        self._store = store or InMemoryRuntimeStore()
+        self._adapter = adapter or AnthropicRuntimeAdapter()
+        self._policy = policy or ApprovalPolicy()
+        self._sync = convex_sync or ConvexAgentStateSync()
+
+    async def create_thread(self, request: ThreadCreateRequest) -> ThreadRecord:
+        created_at = _now_ms()
+        thread_id = request.external_id or f"thread_{uuid4().hex}"
+
+        existing = await self._store.get_thread(thread_id)
+        if existing:
+            return existing
+
+        thread = ThreadRecord(
+            external_id=thread_id,
+            channel=request.channel,
+            status="active",
+            title=request.title,
+            summary=None,
+            created_by_user_id=request.created_by_user_id,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        await self._store.upsert_thread(thread)
+        await self._sync.upsert_thread(thread)
+
+        if request.context_links:
+            for link in request.context_links:
+                link_now = _now_ms()
+                stored_link = ContextLinkRecord(
+                    link_key=f"{thread.external_id}:{link.entity_type}:{link.entity_id}",
+                    relation=link.relation,
+                    entity_type=link.entity_type,
+                    entity_id=link.entity_id,
+                    label=link.label,
+                    url=link.url,
+                    metadata_json=link.metadata_json,
+                    created_at=link_now,
+                    updated_at=link_now,
+                )
+                await self._store.put_context_link(stored_link)
+                await self._sync.upsert_context_link(thread.external_id, stored_link)
+
+        return thread
+
+    async def get_thread_state(self, thread_id: str) -> ThreadStateResponse:
+        local = await self._store.list_thread_state(thread_id)
+        if local:
+            return local
+
+        state = await self._sync.fetch_thread_state(thread_id)
+        if not state:
+            raise HTTPException(status_code=404, detail=f"Thread not found: {thread_id}")
+
+        hydrated = self._hydrate_thread_state(state)
+        await self._store.upsert_thread(hydrated.thread)
+        for run in hydrated.runs:
+            await self._store.upsert_run(run)
+        for message in hydrated.messages:
+            await self._store.append_message(message)
+        for artifact in hydrated.artifacts:
+            await self._store.upsert_artifact(artifact)
+        for approval in hydrated.approvals:
+            await self._store.upsert_approval(approval)
+        for link in hydrated.context_links:
+            await self._store.put_context_link(link)
+
+        return hydrated
+
+    async def start_run(self, request: RunCreateRequest) -> RunRecord:
+        thread = await self._store.get_thread(request.thread_id)
+        if not thread:
+            await self.get_thread_state(request.thread_id)
+            thread = await self._store.get_thread(request.thread_id)
+        if not thread:
+            raise HTTPException(status_code=404, detail=f"Thread not found: {request.thread_id}")
+
+        now = _now_ms()
+        run = RunRecord(
+            external_id=f"run_{uuid4().hex}",
+            thread_external_id=request.thread_id,
+            status=RunStatus.RUNNING,
+            trigger_source=request.trigger_source,
+            mode=request.mode,
+            initiated_by_user_id=request.initiated_by_user_id,
+            model=self._adapter.model,
+            started_at=now,
+            updated_at=now,
+        )
+        await self._store.upsert_run(run)
+        await self._sync.upsert_run(run)
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="run.started",
+            created_at=now,
+            data={"status": run.status.value},
+        )
+
+        await self._append_message(
+            thread_id=request.thread_id,
+            run_id=run.external_id,
+            role="user",
+            status="final",
+            blocks=[text_block(request.input_text)],
+        )
+
+        action = infer_tool_action_from_text(request.input_text)
+        if action:
+            await self._store.append_stream_event(
+                run_id=run.external_id,
+                event="tool.planned",
+                created_at=_now_ms(),
+                data={"name": action.name, "class": action.action_class.value},
+            )
+
+        if action and self._policy.evaluate(action).requires_approval:
+            run = await self._pause_for_approval(run=run, action=action)
+            return run
+
+        await self._execute_run(run=run, user_input=request.input_text, max_tokens=request.max_tokens)
+        resolved = await self._store.get_run(run.external_id)
+        if not resolved:
+            raise HTTPException(status_code=500, detail="Run state missing after execution")
+        return resolved
+
+    async def list_run_events(self, run_id: str, *, after_sequence: int = 0) -> list:
+        run = await self._store.get_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+        return await self._store.list_stream_events(run_id, after_sequence=after_sequence)
+
+    async def submit_approval(self, approval_id: str, request: ApprovalDecisionRequest) -> ApprovalDecisionResponse:
+        decision_status = ApprovalStatus(request.decision)
+
+        approval = await self._store.get_approval(approval_id)
+        if not approval:
+            raise HTTPException(status_code=404, detail=f"Approval not found: {approval_id}")
+
+        if approval.status != ApprovalStatus.PENDING:
+            run = await self._store.get_run(approval.run_external_id)
+            if not run:
+                raise HTTPException(status_code=500, detail="Run missing for resolved approval")
+            return ApprovalDecisionResponse(approval=approval, run=run)
+
+        now = _now_ms()
+        approval = approval.model_copy(
+            update={
+                "status": decision_status,
+                "decision_note": request.note,
+                "decided_by_user_id": request.decided_by_user_id,
+                "resolved_at": now,
+                "updated_at": now,
+            }
+        )
+        await self._store.upsert_approval(approval)
+        await self._sync.resolve_approval(approval)
+        await self._store.append_stream_event(
+            run_id=approval.run_external_id,
+            event="approval.resolved",
+            created_at=now,
+            data={"approval_id": approval.external_id, "decision": approval.status.value},
+        )
+
+        run = await self._store.get_run(approval.run_external_id)
+        if not run:
+            raise HTTPException(status_code=500, detail="Run missing for approval")
+
+        if approval.status == ApprovalStatus.REJECTED:
+            run = run.model_copy(
+                update={
+                    "status": RunStatus.COMPLETED,
+                    "completed_at": now,
+                    "updated_at": now,
+                    "summary": "Action rejected by user; run finalized.",
+                }
+            )
+            await self._store.upsert_run(run)
+            await self._sync.upsert_run(run)
+            await self._append_message(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                role="assistant",
+                status="final",
+                blocks=[text_block("Action was rejected. No external changes were applied.")],
+            )
+            await self._store.append_stream_event(
+                run_id=run.external_id,
+                event="run.completed",
+                created_at=now,
+                data={"status": run.status.value},
+            )
+            return ApprovalDecisionResponse(approval=approval, run=run)
+
+        pending_action = await self._store.pop_pending_action(run.external_id)
+        if not pending_action and approval.payload_json:
+            try:
+                payload = json.loads(approval.payload_json)
+                pending_action = ToolAction.model_validate(payload)
+            except Exception:
+                pending_action = None
+
+        run = run.model_copy(update={"status": RunStatus.RUNNING, "updated_at": now})
+        await self._store.upsert_run(run)
+        await self._sync.upsert_run(run)
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="run.resumed",
+            created_at=now,
+            data={"status": run.status.value},
+        )
+
+        action_label = pending_action.name if pending_action else "approved_action"
+        await self._append_message(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            role="tool",
+            status="final",
+            blocks=[text_block(f"Approved action executed: {action_label}")],
+        )
+
+        await self._execute_run(
+            run=run,
+            user_input=f"User approved action: {action_label}. Continue and summarize outcomes.",
+            max_tokens=700,
+        )
+
+        resolved_run = await self._store.get_run(run.external_id)
+        if not resolved_run:
+            raise HTTPException(status_code=500, detail="Run state missing after approval execution")
+        return ApprovalDecisionResponse(approval=approval, run=resolved_run)
+
+    async def _pause_for_approval(self, *, run: RunRecord, action: ToolAction) -> RunRecord:
+        decision = self._policy.evaluate(action)
+        now = _now_ms()
+        approval = ApprovalRecord(
+            external_id=f"approval_{uuid4().hex}",
+            thread_external_id=run.thread_external_id,
+            run_external_id=run.external_id,
+            status=ApprovalStatus.PENDING,
+            action_type=action.action_class.value,
+            title=f"Approval required: {action.name}",
+            summary=decision.reason,
+            risk_level=decision.risk_level,
+            payload_json=json.dumps(action.model_dump()),
+            requested_at=now,
+            updated_at=now,
+        )
+        run = run.model_copy(
+            update={
+                "status": RunStatus.PAUSED_APPROVAL,
+                "summary": "Paused pending approval.",
+                "updated_at": now,
+            }
+        )
+
+        await self._store.upsert_approval(approval)
+        await self._sync.upsert_approval(approval)
+        await self._store.set_pending_action(run.external_id, action)
+        await self._store.upsert_run(run)
+        await self._sync.upsert_run(run)
+
+        await self._append_message(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            role="assistant",
+            status="final",
+            blocks=[text_block("This action requires approval before execution.")],
+        )
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="approval.requested",
+            created_at=now,
+            data={
+                "approval_id": approval.external_id,
+                "action_type": approval.action_type,
+                "risk_level": approval.risk_level.value,
+            },
+        )
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="run.paused",
+            created_at=now,
+            data={"status": run.status.value},
+        )
+        return run
+
+    async def _execute_run(self, *, run: RunRecord, user_input: str, max_tokens: int) -> None:
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="assistant.stream_started",
+            created_at=_now_ms(),
+            data={},
+        )
+
+        latest_text = ""
+        try:
+            async for partial_text in self._adapter.stream_text(
+                user_prompt=user_input,
+                max_tokens=max_tokens,
+            ):
+                latest_text = partial_text
+                await self._store.append_stream_event(
+                    run_id=run.external_id,
+                    event="assistant.delta",
+                    created_at=_now_ms(),
+                    data={"text": partial_text},
+                )
+        except Exception as exc:
+            now = _now_ms()
+            failed = run.model_copy(
+                update={
+                    "status": RunStatus.ERROR,
+                    "error_message": str(exc),
+                    "updated_at": now,
+                    "completed_at": now,
+                }
+            )
+            await self._store.upsert_run(failed)
+            await self._sync.upsert_run(failed)
+            await self._store.append_stream_event(
+                run_id=run.external_id,
+                event="run.error",
+                created_at=now,
+                data={"message": str(exc)},
+            )
+            return
+
+        assistant_message = await self._append_message(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            role="assistant",
+            status="final",
+            blocks=[text_block(latest_text)],
+        )
+
+        artifact = make_report_artifact(
+            external_id=f"artifact_{uuid4().hex}",
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            title="Run Summary",
+            summary="Normalized runtime output",
+            report_text=latest_text,
+            sort_order=1,
+        )
+        await self._store.upsert_artifact(artifact)
+        await self._sync.upsert_artifact(artifact)
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="artifact.created",
+            created_at=_now_ms(),
+            data={"artifact_id": artifact.external_id, "kind": artifact.kind.value},
+        )
+
+        now = _now_ms()
+        completed = run.model_copy(
+            update={
+                "status": RunStatus.COMPLETED,
+                "summary": "Run completed successfully.",
+                "completed_at": now,
+                "updated_at": now,
+                "latest_message_sequence": assistant_message.sequence_number,
+            }
+        )
+        await self._store.upsert_run(completed)
+        await self._sync.upsert_run(completed)
+        await self._store.append_stream_event(
+            run_id=run.external_id,
+            event="run.completed",
+            created_at=now,
+            data={"status": completed.status.value},
+        )
+
+    async def _append_message(
+        self,
+        *,
+        thread_id: str,
+        run_id: str,
+        role: str,
+        status: str,
+        blocks: list,
+    ) -> MessageRecord:
+        now = _now_ms()
+        sequence = await self._store.next_sequence(thread_id)
+        message = MessageRecord(
+            external_id=f"msg_{uuid4().hex}",
+            thread_external_id=thread_id,
+            run_external_id=run_id,
+            role=role,
+            status=status,
+            sequence_number=sequence,
+            plain_text="\n".join(block.text for block in blocks if block.text).strip() or None,
+            content_blocks=blocks,
+            created_at=now,
+            updated_at=now,
+        )
+        await self._store.append_message(message)
+        await self._sync.append_message(message)
+        await self._store.append_stream_event(
+            run_id=run_id,
+            event="message.created",
+            created_at=now,
+            data={"message_id": message.external_id, "role": role, "sequence": sequence},
+        )
+
+        thread = await self._store.get_thread(thread_id)
+        if thread:
+            updated_thread = thread.model_copy(update={"last_message_at": now, "updated_at": now})
+            await self._store.upsert_thread(updated_thread)
+            await self._sync.upsert_thread(updated_thread)
+
+        return message
+
+    def _hydrate_thread_state(self, state: dict) -> ThreadStateResponse:
+        thread_data = state.get("thread")
+        if not isinstance(thread_data, dict):
+            raise HTTPException(status_code=404, detail="Thread state payload missing thread")
+
+        thread = ThreadRecord(
+            external_id=str(thread_data.get("external_id")),
+            channel=thread_data.get("channel", "web"),
+            status=thread_data.get("status", "active"),
+            title=thread_data.get("title"),
+            summary=thread_data.get("summary"),
+            created_by_user_id=thread_data.get("created_by_user_id"),
+            last_message_at=thread_data.get("last_message_at"),
+            last_run_started_at=thread_data.get("last_run_started_at"),
+            archived_at=thread_data.get("archived_at"),
+            created_at=thread_data.get("created_at") or _now_ms(),
+            updated_at=thread_data.get("updated_at") or _now_ms(),
+        )
+
+        runs = [
+            RunRecord(
+                external_id=str(item.get("external_id")),
+                thread_external_id=thread.external_id,
+                status=item.get("status", "running"),
+                trigger_source=item.get("trigger_source", "web"),
+                mode=item.get("mode"),
+                initiated_by_user_id=item.get("initiated_by_user_id"),
+                model=item.get("model"),
+                summary=item.get("summary"),
+                error_message=item.get("error_message"),
+                started_at=item.get("started_at") or _now_ms(),
+                completed_at=item.get("completed_at"),
+                updated_at=item.get("updated_at") or _now_ms(),
+                latest_message_sequence=item.get("latest_message_sequence"),
+            )
+            for item in state.get("runs", [])
+            if isinstance(item, dict)
+        ]
+
+        messages = [
+            MessageRecord(
+                external_id=str(item.get("external_id")),
+                thread_external_id=thread.external_id,
+                run_external_id=item.get("run_id") and str(item.get("run_id")),
+                role=item.get("role", "assistant"),
+                status=item.get("status", "final"),
+                sequence_number=item.get("sequence_number", 0),
+                plain_text=item.get("plain_text"),
+                content_blocks=item.get("content_blocks", []),
+                created_at=item.get("created_at") or _now_ms(),
+                updated_at=item.get("updated_at") or _now_ms(),
+            )
+            for item in state.get("messages", [])
+            if isinstance(item, dict)
+        ]
+
+        artifacts = [
+            ArtifactRecord(
+                external_id=str(item.get("external_id")),
+                thread_external_id=thread.external_id,
+                run_external_id=item.get("run_id") and str(item.get("run_id")),
+                kind=item.get("kind", "report"),
+                status=item.get("status", "ready"),
+                sort_order=item.get("sort_order", 0),
+                title=item.get("title"),
+                summary=item.get("summary"),
+                content_blocks=item.get("content_blocks", []),
+                created_at=item.get("created_at") or _now_ms(),
+                updated_at=item.get("updated_at") or _now_ms(),
+            )
+            for item in state.get("artifacts", [])
+            if isinstance(item, dict)
+        ]
+
+        approvals = [
+            ApprovalRecord(
+                external_id=str(item.get("external_id")),
+                thread_external_id=thread.external_id,
+                run_external_id=str(item.get("run_id")),
+                status=item.get("status", "pending"),
+                action_type=item.get("action_type", "write"),
+                title=item.get("title", "Approval"),
+                summary=item.get("summary"),
+                risk_level=item.get("risk_level", "medium"),
+                payload_json=item.get("payload_json"),
+                requested_at=item.get("requested_at") or _now_ms(),
+                expires_at=item.get("expires_at"),
+                resolved_at=item.get("resolved_at"),
+                decision_note=item.get("decision_note"),
+                decided_by_user_id=item.get("decided_by_user_id"),
+                updated_at=item.get("updated_at") or _now_ms(),
+            )
+            for item in state.get("approvals", [])
+            if isinstance(item, dict)
+        ]
+
+        context_links = [
+            ContextLinkRecord(
+                link_key=str(item.get("link_key")),
+                relation=item.get("relation", "context"),
+                entity_type=item.get("entity_type", "event"),
+                entity_id=item.get("entity_id", ""),
+                label=item.get("label"),
+                url=item.get("url"),
+                metadata_json=item.get("metadata_json"),
+                created_at=item.get("created_at") or _now_ms(),
+                updated_at=item.get("updated_at") or _now_ms(),
+            )
+            for item in state.get("context_links", [])
+            if isinstance(item, dict)
+        ]
+
+        return ThreadStateResponse(
+            thread=thread,
+            runs=runs,
+            messages=messages,
+            artifacts=artifacts,
+            approvals=approvals,
+            context_links=context_links,
+        )

--- a/agent/runtime/store.py
+++ b/agent/runtime/store.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any
+
+from runtime.contracts import (
+    ApprovalRecord,
+    ArtifactRecord,
+    ContextLinkRecord,
+    MessageRecord,
+    RunRecord,
+    StreamEvent,
+    ThreadRecord,
+    ThreadStateResponse,
+)
+from runtime.policy import ToolAction
+
+
+class InMemoryRuntimeStore:
+    """In-memory runtime state store for local execution and tests."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self.threads: dict[str, ThreadRecord] = {}
+        self.runs: dict[str, RunRecord] = {}
+        self.messages: dict[str, MessageRecord] = {}
+        self.artifacts: dict[str, ArtifactRecord] = {}
+        self.approvals: dict[str, ApprovalRecord] = {}
+        self.context_links: dict[str, ContextLinkRecord] = {}
+
+        self._thread_sequences: dict[str, int] = defaultdict(int)
+        self._run_event_sequences: dict[str, int] = defaultdict(int)
+        self._run_events: dict[str, list[StreamEvent]] = defaultdict(list)
+        self._pending_actions: dict[str, ToolAction] = {}
+
+    async def upsert_thread(self, record: ThreadRecord) -> None:
+        async with self._lock:
+            self.threads[record.external_id] = record
+
+    async def get_thread(self, thread_id: str) -> ThreadRecord | None:
+        return self.threads.get(thread_id)
+
+    async def upsert_run(self, record: RunRecord) -> None:
+        async with self._lock:
+            self.runs[record.external_id] = record
+
+    async def get_run(self, run_id: str) -> RunRecord | None:
+        return self.runs.get(run_id)
+
+    async def append_message(self, record: MessageRecord) -> None:
+        async with self._lock:
+            self.messages[record.external_id] = record
+            current = self._thread_sequences[record.thread_external_id]
+            self._thread_sequences[record.thread_external_id] = max(current, record.sequence_number)
+
+    async def upsert_artifact(self, record: ArtifactRecord) -> None:
+        async with self._lock:
+            self.artifacts[record.external_id] = record
+
+    async def upsert_approval(self, record: ApprovalRecord) -> None:
+        async with self._lock:
+            self.approvals[record.external_id] = record
+
+    async def get_approval(self, approval_id: str) -> ApprovalRecord | None:
+        return self.approvals.get(approval_id)
+
+    async def put_context_link(self, link: ContextLinkRecord) -> None:
+        async with self._lock:
+            self.context_links[link.link_key] = link
+
+    async def set_pending_action(self, run_id: str, action: ToolAction) -> None:
+        async with self._lock:
+            self._pending_actions[run_id] = action
+
+    async def pop_pending_action(self, run_id: str) -> ToolAction | None:
+        async with self._lock:
+            return self._pending_actions.pop(run_id, None)
+
+    async def next_sequence(self, thread_id: str) -> int:
+        async with self._lock:
+            self._thread_sequences[thread_id] += 1
+            return self._thread_sequences[thread_id]
+
+    async def append_stream_event(
+        self,
+        *,
+        run_id: str,
+        event: str,
+        created_at: int,
+        data: dict[str, Any] | None = None,
+    ) -> StreamEvent:
+        async with self._lock:
+            self._run_event_sequences[run_id] += 1
+            record = StreamEvent(
+                run_id=run_id,
+                sequence=self._run_event_sequences[run_id],
+                event=event,
+                created_at=created_at,
+                data=data or {},
+            )
+            self._run_events[run_id].append(record)
+            return record
+
+    async def list_stream_events(self, run_id: str, *, after_sequence: int = 0) -> list[StreamEvent]:
+        events = self._run_events.get(run_id, [])
+        return [event for event in events if event.sequence > after_sequence]
+
+    async def list_thread_state(self, thread_id: str) -> ThreadStateResponse | None:
+        thread = self.threads.get(thread_id)
+        if not thread:
+            return None
+
+        runs = [row for row in self.runs.values() if row.thread_external_id == thread_id]
+        messages = [row for row in self.messages.values() if row.thread_external_id == thread_id]
+        artifacts = [row for row in self.artifacts.values() if row.thread_external_id == thread_id]
+        approvals = [row for row in self.approvals.values() if row.thread_external_id == thread_id]
+        context_links = [row for row in self.context_links.values() if row.link_key.startswith(f"{thread_id}:")]
+
+        runs.sort(key=lambda row: row.updated_at, reverse=True)
+        messages.sort(key=lambda row: row.sequence_number)
+        artifacts.sort(key=lambda row: row.sort_order)
+        approvals.sort(key=lambda row: row.requested_at, reverse=True)
+        context_links.sort(key=lambda row: row.created_at)
+
+        return ThreadStateResponse(
+            thread=thread,
+            runs=runs,
+            messages=messages,
+            artifacts=artifacts,
+            approvals=approvals,
+            context_links=context_links,
+        )

--- a/agent/tests/test_mcp_server_io.py
+++ b/agent/tests/test_mcp_server_io.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import pytest
+
+import mcp_server
+
+
+def _sample_record(record_id: str = "rec_123") -> dict:
+    return {
+        "id": {"record_id": record_id},
+        "created_at": "2026-04-01T00:00:00Z",
+        "values": {
+            "name": [{"first_name": "Ada", "last_name": "Lovelace"}],
+            "email_addresses": [{"email_address": "ada@example.com"}],
+            "phone_numbers": [{"phone_number": "+1-555-0100"}],
+            "career_profile": [{"value": "{\"skills\": [\"python\"]}"}],
+            "relationship_stage": [{"value": "active"}],
+            "contact_source": [{"value": "warm_intro"}],
+            "warm_intro_by": [{"value": "Grace"}],
+            "assigned_members": [{"value": "[\"owner@example.com\"]"}],
+            "contact_type": [{"value": "speaker"}],
+            "outreach_status": [{"value": "agent_active"}],
+            "enrichment_status": [{"value": "enriched"}],
+            "last_agent_action_at": [{"value": "2026-04-01T12:00:00Z"}],
+        },
+    }
+
+
+class FakeAttioClient:
+    def __init__(self, state: dict) -> None:
+        self.state = state
+
+    async def __aenter__(self) -> "FakeAttioClient":
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    async def search_contacts(self, filter_: dict, limit: int = 100, offset: int = 0) -> list[dict]:
+        self.state["search_calls"].append({"filter": filter_, "limit": limit, "offset": offset})
+        return self.state.get("search_result", [])
+
+    async def get_contact(self, record_id: str) -> dict:
+        self.state["get_calls"].append(record_id)
+        return self.state.get("get_result", _sample_record(record_id))
+
+    async def create_contact(self, values: dict) -> dict:
+        self.state["create_calls"].append(values)
+        return self.state.get("create_result", _sample_record("created_1"))
+
+    async def update_contact(self, record_id: str, values: dict) -> dict:
+        self.state["update_calls"].append({"record_id": record_id, "values": values})
+        return self.state.get("update_result", _sample_record(record_id))
+
+    async def create_note(self, record_id: str, title: str, content: str) -> dict:
+        self.state["note_calls"].append(
+            {"record_id": record_id, "title": title, "content": content}
+        )
+        return {"id": {"note_id": "note_1"}}
+
+
+def _install_fake_attio(monkeypatch: pytest.MonkeyPatch, state: dict) -> None:
+    monkeypatch.setattr(mcp_server, "AttioClient", lambda: FakeAttioClient(state))
+
+
+@pytest.mark.asyncio
+async def test_search_contacts_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "search_result": [_sample_record("rec_1")],
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    rows = await mcp_server.search_contacts(
+        outreach_status="pending",
+        contact_source="warm_intro",
+        limit=7,
+    )
+
+    assert len(state["search_calls"]) == 1
+    call = state["search_calls"][0]
+    assert call["limit"] == 7
+    assert call["filter"] == {
+        "$and": [
+            {
+                "attribute": {"slug": "outreach_status"},
+                "condition": "equals",
+                "value": "pending",
+            },
+            {
+                "attribute": {"slug": "contact_source"},
+                "condition": "equals",
+                "value": "warm_intro",
+            },
+        ]
+    }
+
+    assert rows[0]["id"] == "rec_1"
+    assert rows[0]["firstname"] == "Ada"
+    assert rows[0]["outreach_status"] == "agent_active"
+
+
+@pytest.mark.asyncio
+async def test_search_contacts_io_without_filters_uses_empty_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "search_result": [_sample_record("rec_2")],
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    rows = await mcp_server.search_contacts(limit=3)
+
+    assert len(state["search_calls"]) == 1
+    call = state["search_calls"][0]
+    assert call["filter"] == {}
+    assert call["limit"] == 3
+    assert rows[0]["id"] == "rec_2"
+
+
+@pytest.mark.asyncio
+async def test_get_contact_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "get_result": _sample_record("rec_777"),
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    row = await mcp_server.get_contact("rec_777")
+
+    assert state["get_calls"] == ["rec_777"]
+    assert row["id"] == "rec_777"
+    assert row["email"] == "ada@example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_contact_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "create_result": _sample_record("created_22"),
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    created = await mcp_server.create_contact(
+        firstname="Ada",
+        lastname="Lovelace",
+        email="ada@example.com",
+        contact_source="warm_intro",
+        contact_type="speaker",
+        career_profile='{"skills":["python"]}',
+        warm_intro_by="Grace Hopper",
+        assigned_members='["member@example.com"]',
+    )
+
+    assert len(state["create_calls"]) == 1
+    values = state["create_calls"][0]
+    assert values["name"] == [{"first_name": "Ada", "last_name": "Lovelace"}]
+    assert values["email_addresses"] == [{"email_address": "ada@example.com"}]
+    assert values["contact_source"] == [{"value": "warm_intro"}]
+    assert values["contact_type"] == [{"value": "speaker"}]
+    assert values["outreach_status"] == [{"value": "pending"}]
+    assert values["career_profile"] == [{"value": '{"skills":["python"]}'}]
+    assert values["warm_intro_by"] == [{"value": "Grace Hopper"}]
+    assert values["assigned_members"] == [{"value": '["member@example.com"]'}]
+
+    assert created["id"] == "created_22"
+    assert created["lastname"] == "Lovelace"
+
+
+@pytest.mark.asyncio
+async def test_update_contact_io_with_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "update_result": _sample_record("rec_abc"),
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    updated = await mcp_server.update_contact(
+        record_id="rec_abc",
+        outreach_status="agent_active",
+        relationship_stage="active",
+        agent_notes="Reached out and awaiting response",
+    )
+
+    assert len(state["note_calls"]) == 1
+    note = state["note_calls"][0]
+    assert note["record_id"] == "rec_abc"
+    assert note["title"] == "Agent Note"
+    assert "Reached out and awaiting response" in note["content"]
+
+    assert len(state["update_calls"]) == 1
+    update_values = state["update_calls"][0]["values"]
+    assert update_values["outreach_status"] == [{"value": "agent_active"}]
+    assert update_values["relationship_stage"] == [{"value": "active"}]
+    assert "last_agent_action_at" in update_values
+    assert isinstance(update_values["last_agent_action_at"][0]["value"], str)
+
+    assert updated["id"] == "rec_abc"
+    assert updated["contact_source"] == "warm_intro"
+
+
+@pytest.mark.asyncio
+async def test_update_contact_timestamp_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "update_result": _sample_record("rec_ts"),
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    updated = await mcp_server.update_contact(
+        record_id="rec_ts",
+        last_agent_action_at="2026-04-01T10:11:12Z",
+    )
+
+    assert not state["note_calls"]
+    assert len(state["update_calls"]) == 1
+    update = state["update_calls"][0]
+    assert update["record_id"] == "rec_ts"
+    assert update["values"] == {
+        "last_agent_action_at": [{"value": "2026-04-01T10:11:12Z"}]
+    }
+    assert updated["id"] == "rec_ts"
+
+
+@pytest.mark.asyncio
+async def test_update_contact_no_updates_reads_contact(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {
+        "search_calls": [],
+        "get_calls": [],
+        "create_calls": [],
+        "update_calls": [],
+        "note_calls": [],
+        "get_result": _sample_record("rec_read"),
+    }
+    _install_fake_attio(monkeypatch, state)
+
+    updated = await mcp_server.update_contact(record_id="rec_read")
+
+    assert not state["note_calls"]
+    assert not state["update_calls"]
+    assert state["get_calls"] == ["rec_read"]
+    assert updated["id"] == "rec_read"

--- a/agent/tests/test_runtime_api.py
+++ b/agent/tests/test_runtime_api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from runtime.api import build_app
+from runtime.service import AgentRuntimeService
+from runtime.store import InMemoryRuntimeStore
+
+
+class FakeAdapter:
+    model = "fake-model"
+
+    async def stream_text(self, *, user_prompt: str, system_prompt: str | None = None, max_tokens: int = 900):
+        _ = (system_prompt, max_tokens)
+        yield "Step 1"
+        yield f"Done: {user_prompt[:15]}"
+
+
+def test_runtime_api_thread_run_stream_and_approval_flow() -> None:
+    service = AgentRuntimeService(store=InMemoryRuntimeStore(), adapter=FakeAdapter())
+    app = build_app(service)
+
+    client = TestClient(app)
+
+    thread_resp = client.post(
+        "/agent/threads",
+        json={"channel": "web", "title": "API Thread"},
+    )
+    assert thread_resp.status_code == 200
+    thread_id = thread_resp.json()["external_id"]
+
+    run_resp = client.post(
+        "/agent/runs",
+        json={
+            "thread_id": thread_id,
+            "input_text": "Send email to finalists",
+            "trigger_source": "web",
+        },
+    )
+    assert run_resp.status_code == 200
+    run_id = run_resp.json()["external_id"]
+    assert run_resp.json()["status"] == "paused_approval"
+
+    stream_resp = client.get(f"/agent/runs/{run_id}/stream")
+    assert stream_resp.status_code == 200
+    assert "approval.requested" in stream_resp.text
+    assert "provider_event" not in stream_resp.text
+
+    state_resp = client.get(f"/agent/threads/{thread_id}")
+    assert state_resp.status_code == 200
+    approvals = state_resp.json()["approvals"]
+    assert len(approvals) == 1
+    approval_id = approvals[0]["external_id"]
+
+    approval_resp = client.post(
+        f"/agent/approvals/{approval_id}",
+        json={"decision": "approved"},
+    )
+    assert approval_resp.status_code == 200
+    assert approval_resp.json()["approval"]["status"] == "approved"
+    assert approval_resp.json()["run"]["status"] == "completed"

--- a/agent/tests/test_runtime_normalize.py
+++ b/agent/tests/test_runtime_normalize.py
@@ -1,0 +1,43 @@
+import json
+
+from runtime.normalize import as_sse, make_report_artifact, text_block
+from runtime.contracts import StreamEvent
+
+
+def test_make_report_artifact_serializes_metadata() -> None:
+    artifact = make_report_artifact(
+        external_id="artifact_1",
+        thread_id="thread_1",
+        run_id="run_1",
+        title="Summary",
+        summary="run output",
+        report_text="hello world",
+        sort_order=1,
+    )
+
+    assert artifact.kind.value == "report"
+    assert artifact.content_blocks[0].text == "hello world"
+
+    metadata = json.loads(artifact.content_blocks[1].data_json or "{}")
+    assert metadata["source"] == "modal_runtime"
+
+
+def test_as_sse_never_emits_raw_provider_payload() -> None:
+    event = StreamEvent(
+        run_id="run_1",
+        sequence=1,
+        event="assistant.delta",
+        created_at=100,
+        data={"text": "partial"},
+    )
+
+    payload = as_sse(event)
+    assert payload.startswith("event: assistant.delta")
+    assert "provider_event" not in payload
+
+
+def test_text_block_is_normalized() -> None:
+    block = text_block("hi", label="greeting")
+    assert block.kind == "text"
+    assert block.text == "hi"
+    assert block.label == "greeting"

--- a/agent/tests/test_runtime_policy.py
+++ b/agent/tests/test_runtime_policy.py
@@ -1,0 +1,37 @@
+from runtime.contracts import RiskLevel
+from runtime.policy import (
+    ActionClass,
+    ApprovalPolicy,
+    ToolAction,
+    infer_tool_action_from_text,
+)
+
+
+def test_policy_requires_approval_for_send() -> None:
+    policy = ApprovalPolicy()
+    action = ToolAction(name="send_email", action_class=ActionClass.SEND)
+    decision = policy.evaluate(action)
+
+    assert decision.requires_approval
+    assert decision.risk_level == RiskLevel.MEDIUM
+
+
+def test_policy_allows_read_without_approval() -> None:
+    policy = ApprovalPolicy()
+    action = ToolAction(name="query", action_class=ActionClass.READ)
+    decision = policy.evaluate(action)
+
+    assert not decision.requires_approval
+    assert decision.risk_level == RiskLevel.LOW
+
+
+def test_infer_tool_action_detects_destructive() -> None:
+    action = infer_tool_action_from_text("Delete the outreach row")
+    assert action is not None
+    assert action.action_class == ActionClass.DESTRUCTIVE
+
+
+def test_infer_tool_action_detects_send() -> None:
+    action = infer_tool_action_from_text("Send an email update")
+    assert action is not None
+    assert action.action_class == ActionClass.SEND

--- a/agent/tests/test_runtime_service.py
+++ b/agent/tests/test_runtime_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from runtime.contracts import ApprovalDecisionRequest, ApprovalStatus, RunCreateRequest, ThreadCreateRequest
+from runtime.policy import ApprovalPolicy
+from runtime.service import AgentRuntimeService
+from runtime.store import InMemoryRuntimeStore
+
+
+class FakeAdapter:
+    model = "fake-model"
+
+    async def stream_text(self, *, user_prompt: str, system_prompt: str | None = None, max_tokens: int = 900) -> AsyncIterator[str]:
+        _ = (system_prompt, max_tokens)
+        yield f"Processed: {user_prompt[:20]}"
+        yield f"Processed: {user_prompt[:20]} complete"
+
+
+@pytest.mark.asyncio
+async def test_start_run_without_approval_completes() -> None:
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Test thread"))
+    run = await service.start_run(RunCreateRequest(thread_id=thread.external_id, input_text="Summarize the agenda"))
+
+    assert run.status.value == "completed"
+
+    state = await service.get_thread_state(thread.external_id)
+    assert len(state.messages) >= 2
+    assert any(message.role == "assistant" for message in state.messages)
+    assert len(state.artifacts) == 1
+    assert not state.approvals
+
+
+@pytest.mark.asyncio
+async def test_start_run_with_send_pauses_for_approval_and_resumes() -> None:
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Approval thread"))
+    run = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Send outreach email to speakers")
+    )
+
+    assert run.status.value == "paused_approval"
+
+    state = await service.get_thread_state(thread.external_id)
+    assert len(state.approvals) == 1
+    approval = state.approvals[0]
+    assert approval.status.value == "pending"
+
+    decision = await service.submit_approval(
+        approval.external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.APPROVED),
+    )
+
+    assert decision.approval.status.value == "approved"
+    assert decision.run.status.value == "completed"
+
+
+@pytest.mark.asyncio
+async def test_rejected_approval_finalizes_without_execution() -> None:
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Reject thread"))
+    run = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Delete this event")
+    )
+    assert run.status.value == "paused_approval"
+
+    state = await service.get_thread_state(thread.external_id)
+    approval = state.approvals[0]
+
+    decision = await service.submit_approval(
+        approval.external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.REJECTED),
+    )
+
+    assert decision.approval.status.value == "rejected"
+    assert decision.run.status.value == "completed"


### PR DESCRIPTION
## Summary
- add a shared Modal-hosted conversational runtime under `agent/runtime` as the canonical execution layer
- implement endpoint surface:
  - `POST /agent/threads`
  - `GET /agent/threads/:id`
  - `POST /agent/runs`
  - `GET /agent/runs/:id/stream`
  - `POST /agent/approvals/:id`
- wrap Anthropic usage behind `AnthropicRuntimeAdapter` and keep runtime policy/normalization/sync local
- add approval-gated action policy (read/analyze/fetch auto-exec; write/send/destructive require approval)
- add normalized in-memory store + Convex sync helpers for thread/run/message/artifact/approval/context-link records
- add MCP I/O tests for `search_contacts`, `get_contact`, `create_contact`, `update_contact` branches

## Files
- `agent/runtime/*`
- `agent/tests/test_runtime_*.py`
- `agent/tests/test_mcp_server_io.py`
- `agent/README.md`

## Validation
- `cd agent && .venv/bin/python -m pytest tests/test_runtime_*.py tests/test_mcp_server_io.py -q`
- result: `18 passed`

## Notes
- runtime stream emits normalized SSE events, not raw provider payloads
- Convex sync is best-effort and uses existing `agentState:*` mutations/queries when env vars are present
