### PR TITLE
Restore attendance data insights dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Convex is the operational application database.
 
 - `events` stores event objects.
 - `event_outreach` stores event-specific outreach links, thread ids, response metadata, and retry-safe processing state.
+- `attendance` stores per-event attendee check-ins keyed by Convex event id and attendee email.
+- `attendance_insights` stores generated attendance analysis snapshots for the dashboard data page.
 - `eboard_members` stores internal club members.
 - `contact_assignments` stores internal ownership history.
 - `inbound_receipts` stores webhook dedupe state.
@@ -142,6 +144,34 @@ Current intended meaning:
 - `inbound_state` = internal processing state only
 
 `inbound_state` must never replace `speakers.status`.
+
+#### `attendance`
+
+Stores event-specific attendee check-ins.
+
+Current intended meaning:
+
+- `event_id` = Convex `events._id`
+- `email` = normalized attendee email
+- `name` = optional attendee display name from the import source
+- `checked_in_at` = write timestamp for the attendance record
+- `source` = optional ingest source such as `manual` or `csv_import`
+
+`attendance` is the source for attendee analytics on `/dashboard/data`. It must remain deduplicated by `(event_id, email)`.
+
+#### `attendance_insights`
+
+Stores AI-generated or manually authored summaries derived from attendance analytics.
+
+Current intended meaning:
+
+- `generated_at` = timestamp when the insight was written
+- `insight_text` = short analysis shown on the dashboard
+- `data_snapshot` = optional JSON payload used as model context
+- `event_count` = number of tracked events in the analyzed snapshot
+- `attendee_count` = unique attendee count in the analyzed snapshot
+
+`attendance_insights` is append-only history; the frontend reads the most recent row.
 
 #### `agent_threads`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,6 +37,8 @@ Existing business tables:
 
 - `events`
 - `event_outreach`
+- `attendance`
+- `attendance_insights`
 - `eboard_members`
 - `contact_assignments`
 - `inbound_receipts`
@@ -199,6 +201,34 @@ Current intended meaning:
 - `inbound_state` = internal processing state only
 
 `inbound_state` must never replace `speakers.status`.
+
+#### `attendance`
+
+Stores event-specific attendee check-ins.
+
+Current intended meaning:
+
+- `event_id` = Convex `events._id`
+- `email` = normalized attendee email
+- `name` = optional attendee display name from the import source
+- `checked_in_at` = write timestamp for the attendance record
+- `source` = optional ingest source such as `manual` or `csv_import`
+
+`attendance` is the source for attendee analytics on `/dashboard/data`. It must remain deduplicated by `(event_id, email)`.
+
+#### `attendance_insights`
+
+Stores generated attendance analysis snapshots for the dashboard data page.
+
+Current intended meaning:
+
+- `generated_at` = timestamp when the insight was written
+- `insight_text` = short analysis shown on the dashboard
+- `data_snapshot` = optional JSON payload used as model context
+- `event_count` = number of tracked events in the analyzed snapshot
+- `attendee_count` = unique attendee count in the analyzed snapshot
+
+`attendance_insights` is append-only history; the frontend reads the most recent row.
 
 #### `eboard_members`
 

--- a/fe+convex/app/dashboard/data/page.tsx
+++ b/fe+convex/app/dashboard/data/page.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { DashboardPageShell } from "@/components/dashboard/PageShell";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+function formatDate(value?: string | null) {
+  if (!value) return "TBD";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString();
+}
+
+function formatTimestamp(value?: number | null) {
+  if (!value) return "No activity yet";
+  return new Date(value).toLocaleString();
+}
+
+function formatSourceLabel(source: string) {
+  return source.replace(/_/g, " ");
+}
+
+export default function DataInsightsPage() {
+  const events = useQuery(api.events.listEvents, {});
+  const dashboard = useQuery(api.attendance.getAttendanceDashboard, {});
+  const upsertAttendanceBatch = useMutation(api.attendance.upsertAttendanceBatch);
+  const recordAttendanceInsight = useMutation(api.attendance.recordAttendanceInsight);
+
+  const [selectedEventId, setSelectedEventId] = useState<Id<"events"> | "">("");
+  const [attendeeName, setAttendeeName] = useState("");
+  const [attendeeEmail, setAttendeeEmail] = useState("");
+  const [attendeeSource, setAttendeeSource] = useState("manual");
+  const [insightText, setInsightText] = useState("");
+  const [submittingAttendance, setSubmittingAttendance] = useState(false);
+  const [submittingInsight, setSubmittingInsight] = useState(false);
+  const [attendanceMessage, setAttendanceMessage] = useState<string | null>(null);
+  const [insightMessage, setInsightMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedEventId && events && events.length > 0) {
+      setSelectedEventId(events[0]._id);
+    }
+  }, [events, selectedEventId]);
+
+  const totals = dashboard?.totals ?? {
+    events_tracked: 0,
+    unique_attendees: 0,
+    total_check_ins: 0,
+    latest_check_in_at: null,
+    by_source: {},
+  };
+  const trackedEvents = dashboard?.event_breakdown ?? [];
+  const repeatAttendees = dashboard?.repeat_attendees ?? [];
+  const recentAttendance = dashboard?.recent_attendance ?? [];
+  const latestInsight = dashboard?.latest_insight ?? null;
+  const sourceEntries = Object.entries(totals.by_source).sort((a, b) => b[1] - a[1]);
+
+  async function handleAttendanceSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setAttendanceMessage(null);
+
+    if (!selectedEventId) {
+      setErrorMessage("Create an event before logging attendance.");
+      return;
+    }
+
+    if (!attendeeEmail.trim()) {
+      setErrorMessage("Attendee email is required.");
+      return;
+    }
+
+    setSubmittingAttendance(true);
+    try {
+      const result = await upsertAttendanceBatch({
+        event_id: selectedEventId,
+        attendees: [
+          {
+            email: attendeeEmail,
+            name: attendeeName || undefined,
+            source: attendeeSource,
+          },
+        ],
+      });
+      setAttendanceMessage(
+        `Logged ${result.inserted_count + result.updated_count} attendee record for ${result.event_title}.`
+      );
+      setAttendeeName("");
+      setAttendeeEmail("");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to log attendance.");
+    } finally {
+      setSubmittingAttendance(false);
+    }
+  }
+
+  async function handleInsightSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setInsightMessage(null);
+
+    if (!insightText.trim()) {
+      setErrorMessage("Insight text is required.");
+      return;
+    }
+
+    setSubmittingInsight(true);
+    try {
+      await recordAttendanceInsight({
+        insight_text: insightText,
+      });
+      setInsightMessage("Saved attendance snapshot.");
+      setInsightText("");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to save insight.");
+    } finally {
+      setSubmittingInsight(false);
+    }
+  }
+
+  return (
+    <DashboardPageShell
+      title="Data Insights"
+      action={
+        <div className="rounded-[10px] border border-[#E5E5E5] bg-[#F6F6F6] px-3 py-2 text-right">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#9A9A9A]">
+            Latest Snapshot
+          </p>
+          <p className="mt-1 text-[12px] font-medium text-[#111111]">
+            {latestInsight ? formatTimestamp(latestInsight.generated_at) : "No saved insight yet"}
+          </p>
+        </div>
+      }
+    >
+      <section className="overflow-hidden rounded-[22px] border border-[#E6E6E6] bg-[linear-gradient(135deg,#FFFFFF_0%,#F5F5F5_55%,#EEEEEE_100%)]">
+        <div className="grid gap-6 px-6 py-6 xl:grid-cols-[minmax(0,1.35fr)_320px]">
+          <div className="space-y-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8C8C8C]">
+              Attendance Ledger
+            </p>
+            <div className="max-w-3xl space-y-3">
+              <h2 className="font-[var(--font-outfit)] text-[42px] font-light leading-[0.95] tracking-[-0.05em] text-[#111111]">
+                Restore the operational record for who actually showed up.
+              </h2>
+              <p className="max-w-2xl text-[14px] leading-6 text-[#5F5F5F]">
+                Attendance is tracked in Convex again with event-scoped dedupe, recent check-ins,
+                repeat-attendee detection, and append-only insight snapshots for the dashboard.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-[18px] border border-[#DADADA] bg-[#111111] p-5 text-[#FFFFFF]">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#BBBBBB]">
+              Source Mix
+            </p>
+            <div className="mt-4 space-y-3">
+              {sourceEntries.length > 0 ? (
+                sourceEntries.map(([source, count]) => (
+                  <div
+                    key={source}
+                    className="flex items-center justify-between border-b border-[#2A2A2A] pb-3 last:border-b-0 last:pb-0"
+                  >
+                    <span className="text-[13px] capitalize text-[#D6D6D6]">
+                      {formatSourceLabel(source)}
+                    </span>
+                    <span className="font-[var(--font-outfit)] text-[28px] font-light tracking-[-0.04em]">
+                      {count}
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-[13px] text-[#B5B5B5]">
+                  No attendance imports yet. Use the form below to start the ledger.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {[
+          {
+            label: "tracked events",
+            value: totals.events_tracked,
+            hint: "events with at least one check-in",
+          },
+          {
+            label: "unique attendees",
+            value: totals.unique_attendees,
+            hint: "deduped by normalized email",
+          },
+          {
+            label: "total check-ins",
+            value: totals.total_check_ins,
+            hint: "all attendance rows across events",
+          },
+          {
+            label: "latest activity",
+            value: totals.latest_check_in_at ? formatTimestamp(totals.latest_check_in_at) : "No activity",
+            hint: "most recent recorded attendance",
+          },
+        ].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-[18px] border border-[#EAEAEA] bg-[#FAFAFA] p-4"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#9B9B9B]">
+              {card.label}
+            </p>
+            <p className="mt-3 font-[var(--font-outfit)] text-[32px] font-light tracking-[-0.05em] text-[#111111]">
+              {card.value}
+            </p>
+            <p className="mt-2 text-[12px] text-[#7D7D7D]">{card.hint}</p>
+          </div>
+        ))}
+      </section>
+
+      {(errorMessage || attendanceMessage || insightMessage) && (
+        <section className="rounded-[14px] border border-[#E5E5E5] bg-[#F7F7F7] px-4 py-3 text-[13px] text-[#444444]">
+          {errorMessage ?? attendanceMessage ?? insightMessage}
+        </section>
+      )}
+
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_360px]">
+        <div className="overflow-hidden rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF]">
+          <div className="flex items-center justify-between border-b border-[#ECECEC] px-5 py-4">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+                Event Breakdown
+              </p>
+              <h3 className="mt-1 text-[16px] font-semibold text-[#111111]">
+                Attendance by event
+              </h3>
+            </div>
+            <p className="text-[12px] text-[#7A7A7A]">
+              Sorted by attendee volume, then latest activity
+            </p>
+          </div>
+
+          {dashboard === undefined ? (
+            <div className="p-6 text-[14px] text-[#6F6F6F]">Loading attendance data...</div>
+          ) : trackedEvents.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#ECECEC] bg-[#F8F8F8]">
+                    {["Event", "Date", "Attendees", "Latest check-in", "Sources"].map((heading) => (
+                      <th
+                        key={heading}
+                        className="px-5 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.12em] text-[#9B9B9B]"
+                      >
+                        {heading}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[#F0F0F0]">
+                  {trackedEvents.map((event) => (
+                    <tr key={event.event_id} className="align-top hover:bg-[#FBFBFB]">
+                      <td className="px-5 py-4">
+                        <p className="text-[14px] font-medium text-[#111111]">{event.title}</p>
+                        <p className="mt-1 text-[12px] text-[#8A8A8A]">
+                          Convex event id: {event.event_id}
+                        </p>
+                      </td>
+                      <td className="px-5 py-4 text-[13px] text-[#5C5C5C]">
+                        {formatDate(event.event_date)}
+                      </td>
+                      <td className="px-5 py-4">
+                        <span className="font-[var(--font-outfit)] text-[28px] font-light tracking-[-0.04em] text-[#111111]">
+                          {event.attendee_count}
+                        </span>
+                      </td>
+                      <td className="px-5 py-4 text-[13px] text-[#5C5C5C]">
+                        {formatTimestamp(event.latest_check_in_at)}
+                      </td>
+                      <td className="px-5 py-4 text-[12px] text-[#5F5F5F]">
+                        <div className="flex flex-wrap gap-2">
+                          {Object.entries(event.sources).map(([source, count]) => (
+                            <span
+                              key={source}
+                              className="rounded-full border border-[#DDDDDD] bg-[#F6F6F6] px-2.5 py-1 capitalize"
+                            >
+                              {formatSourceLabel(source)} {count}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="p-6 text-[14px] text-[#6F6F6F]">
+              No attendance records yet. Log an attendee to start the event breakdown.
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-5">
+          <div className="rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF] p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+              Latest Insight
+            </p>
+            {latestInsight ? (
+              <div className="mt-3 space-y-3">
+                <p className="text-[15px] leading-6 text-[#1C1C1C]">
+                  {latestInsight.insight_text}
+                </p>
+                <div className="grid grid-cols-2 gap-3 text-[12px] text-[#707070]">
+                  <div className="rounded-[12px] border border-[#ECECEC] bg-[#FAFAFA] p-3">
+                    <p className="uppercase tracking-[0.12em] text-[#A0A0A0]">events</p>
+                    <p className="mt-2 text-[18px] font-semibold text-[#111111]">
+                      {latestInsight.event_count}
+                    </p>
+                  </div>
+                  <div className="rounded-[12px] border border-[#ECECEC] bg-[#FAFAFA] p-3">
+                    <p className="uppercase tracking-[0.12em] text-[#A0A0A0]">attendees</p>
+                    <p className="mt-2 text-[18px] font-semibold text-[#111111]">
+                      {latestInsight.attendee_count}
+                    </p>
+                  </div>
+                </div>
+                <p className="text-[12px] text-[#8A8A8A]">
+                  Saved {formatTimestamp(latestInsight.generated_at)}
+                </p>
+              </div>
+            ) : (
+              <p className="mt-3 text-[13px] leading-6 text-[#6B6B6B]">
+                No saved insight yet. Capture one after reviewing the attendance patterns below.
+              </p>
+            )}
+          </div>
+
+          <form
+            onSubmit={handleAttendanceSubmit}
+            className="rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF] p-5"
+          >
+            <div className="space-y-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+                Manual Check-In
+              </p>
+              <h3 className="text-[16px] font-semibold text-[#111111]">Log one attendee</h3>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <select
+                value={selectedEventId}
+                onChange={(event) =>
+                  setSelectedEventId(event.target.value as Id<"events"> | "")
+                }
+                className="h-11 w-full rounded-[10px] border border-[#E1E1E1] bg-transparent px-3 text-[14px] text-[#111111] outline-none focus:border-[#111111]"
+                disabled={!events || events.length === 0 || submittingAttendance}
+              >
+                <option value="">Select an event</option>
+                {(events ?? []).map((event) => (
+                  <option key={event._id} value={event._id}>
+                    {event.title}
+                  </option>
+                ))}
+              </select>
+
+              <input
+                value={attendeeName}
+                onChange={(event) => setAttendeeName(event.target.value)}
+                placeholder="Attendee name"
+                className="h-11 w-full rounded-[10px] border border-[#E1E1E1] bg-transparent px-3 text-[14px] text-[#111111] outline-none placeholder:text-[#9A9A9A] focus:border-[#111111]"
+                disabled={submittingAttendance}
+              />
+
+              <input
+                value={attendeeEmail}
+                onChange={(event) => setAttendeeEmail(event.target.value)}
+                placeholder="Attendee email"
+                className="h-11 w-full rounded-[10px] border border-[#E1E1E1] bg-transparent px-3 text-[14px] text-[#111111] outline-none placeholder:text-[#9A9A9A] focus:border-[#111111]"
+                disabled={submittingAttendance}
+              />
+
+              <select
+                value={attendeeSource}
+                onChange={(event) => setAttendeeSource(event.target.value)}
+                className="h-11 w-full rounded-[10px] border border-[#E1E1E1] bg-transparent px-3 text-[14px] text-[#111111] outline-none focus:border-[#111111]"
+                disabled={submittingAttendance}
+              >
+                <option value="manual">manual</option>
+                <option value="csv_import">csv import</option>
+                <option value="door_list">door list</option>
+              </select>
+            </div>
+
+            <button
+              type="submit"
+              disabled={submittingAttendance || !events || events.length === 0}
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-[10px] bg-[#111111] px-4 text-[13px] font-semibold text-[#FFFFFF] transition hover:bg-[#1A1A1A] disabled:cursor-not-allowed disabled:bg-[#B5B5B5]"
+            >
+              {submittingAttendance ? "Logging..." : "Log attendance"}
+            </button>
+          </form>
+
+          <form
+            onSubmit={handleInsightSubmit}
+            className="rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF] p-5"
+          >
+            <div className="space-y-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+                Snapshot Note
+              </p>
+              <h3 className="text-[16px] font-semibold text-[#111111]">
+                Persist the current read
+              </h3>
+            </div>
+
+            <textarea
+              value={insightText}
+              onChange={(event) => setInsightText(event.target.value)}
+              rows={5}
+              placeholder="Example: Repeat attendance is clustering around workshop-format events."
+              className="mt-4 w-full rounded-[10px] border border-[#E1E1E1] bg-transparent px-3 py-3 text-[14px] leading-6 text-[#111111] outline-none placeholder:text-[#9A9A9A] focus:border-[#111111]"
+              disabled={submittingInsight}
+            />
+
+            <button
+              type="submit"
+              disabled={submittingInsight}
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-[10px] border border-[#111111] bg-[#FFFFFF] px-4 text-[13px] font-semibold text-[#111111] transition hover:bg-[#F3F3F3] disabled:cursor-not-allowed disabled:border-[#D0D0D0] disabled:text-[#9A9A9A]"
+            >
+              {submittingInsight ? "Saving..." : "Save insight snapshot"}
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <div className="rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF]">
+          <div className="border-b border-[#ECECEC] px-5 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+              Repeat Attendees
+            </p>
+            <h3 className="mt-1 text-[16px] font-semibold text-[#111111]">
+              People returning across events
+            </h3>
+          </div>
+
+          <div className="divide-y divide-[#F0F0F0]">
+            {repeatAttendees.length > 0 ? (
+              repeatAttendees.map((attendee) => (
+                <div
+                  key={attendee.email}
+                  className="flex items-center justify-between px-5 py-4"
+                >
+                  <div>
+                    <p className="text-[14px] font-medium text-[#111111]">
+                      {attendee.name ?? attendee.email}
+                    </p>
+                    <p className="mt-1 text-[12px] text-[#8A8A8A]">{attendee.email}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-[var(--font-outfit)] text-[28px] font-light tracking-[-0.04em] text-[#111111]">
+                      {attendee.event_count}
+                    </p>
+                    <p className="text-[11px] uppercase tracking-[0.12em] text-[#9A9A9A]">
+                      events
+                    </p>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="px-5 py-6 text-[14px] text-[#6F6F6F]">
+                Repeat attendees will appear here once the same email checks into multiple events.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-[18px] border border-[#E9E9E9] bg-[#FFFFFF]">
+          <div className="border-b border-[#ECECEC] px-5 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#999999]">
+              Recent Check-Ins
+            </p>
+            <h3 className="mt-1 text-[16px] font-semibold text-[#111111]">
+              Latest attendance activity
+            </h3>
+          </div>
+
+          <div className="divide-y divide-[#F0F0F0]">
+            {recentAttendance.length > 0 ? (
+              recentAttendance.map((entry) => (
+                <div key={entry._id} className="px-5 py-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-[14px] font-medium text-[#111111]">
+                        {entry.name ?? entry.email}
+                      </p>
+                      <p className="mt-1 text-[12px] text-[#8A8A8A]">
+                        {entry.event_title} · {formatDate(entry.event_date)}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-[12px] font-medium uppercase tracking-[0.12em] text-[#9A9A9A]">
+                        {entry.source ? formatSourceLabel(entry.source) : "unknown"}
+                      </p>
+                      <p className="mt-1 text-[12px] text-[#666666]">
+                        {formatTimestamp(entry.checked_in_at)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="px-5 py-6 text-[14px] text-[#6F6F6F]">
+                Recent attendance will populate as soon as check-ins are recorded.
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </DashboardPageShell>
+  );
+}

--- a/fe+convex/app/dashboard/layout.tsx
+++ b/fe+convex/app/dashboard/layout.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import DashboardNav from "@/components/DashboardNav";
 import {
+  BarChart3,
   CalendarDays,
   LayoutDashboard,
   Mail,
@@ -31,6 +32,11 @@ const navLinks = [
     href: "/dashboard/events",
     label: "Events",
     icon: CalendarDays,
+  },
+  {
+    href: "/dashboard/data",
+    label: "Data",
+    icon: BarChart3,
   },
   {
     href: "/dashboard/speakers",

--- a/fe+convex/convex/_generated/api.d.ts
+++ b/fe+convex/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as agentState from "../agentState.js";
 import type * as agentStateValidators from "../agentStateValidators.js";
+import type * as attendance from "../attendance.js";
 import type * as auth from "../auth.js";
 import type * as contactAssignments from "../contactAssignments.js";
 import type * as eboard from "../eboard.js";
@@ -29,6 +30,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   agentState: typeof agentState;
   agentStateValidators: typeof agentStateValidators;
+  attendance: typeof attendance;
   auth: typeof auth;
   contactAssignments: typeof contactAssignments;
   eboard: typeof eboard;

--- a/fe+convex/convex/attendance.test.ts
+++ b/fe+convex/convex/attendance.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getAttendanceDashboard,
+  listEventAttendance,
+  recordAttendanceInsight,
+  upsertAttendanceBatch,
+} from "./attendance";
+
+type TableName = "events" | "attendance" | "attendance_insights";
+type TableRow = { _id: string } & Record<string, unknown>;
+type Tables = Record<TableName, TableRow[]>;
+
+class FakeIndexRangeBuilder {
+  readonly filters: Array<[string, unknown]> = [];
+
+  eq(field: string, value: unknown) {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+class FakeQuery {
+  constructor(
+    private readonly rows: TableRow[],
+    private readonly filters: Array<[string, unknown]> = []
+  ) {}
+
+  withIndex(_indexName: string, build: (builder: FakeIndexRangeBuilder) => unknown) {
+    const builder = new FakeIndexRangeBuilder();
+    build(builder);
+    return new FakeQuery(this.rows, builder.filters);
+  }
+
+  async collect() {
+    return this.rows.filter((row) =>
+      this.filters.every(([field, value]) => row[field] === value)
+    );
+  }
+
+  async unique() {
+    const matches = await this.collect();
+    return matches[0] ?? null;
+  }
+}
+
+class FakeDb {
+  private readonly counters: Record<TableName, number> = {
+    events: 0,
+    attendance: 0,
+    attendance_insights: 0,
+  };
+
+  readonly tables: Tables = {
+    events: [],
+    attendance: [],
+    attendance_insights: [],
+  };
+
+  query(table: TableName) {
+    return new FakeQuery(this.tables[table]);
+  }
+
+  async get(id: string) {
+    const table = id.split(":")[0] as TableName;
+    return this.tables[table].find((row) => row._id === id) ?? null;
+  }
+
+  async insert(table: TableName, value: Record<string, unknown>) {
+    const id = `${table}:${++this.counters[table]}`;
+    this.tables[table].push({ _id: id, ...value });
+    return id;
+  }
+
+  async patch(id: string, value: Record<string, unknown>) {
+    const table = id.split(":")[0] as TableName;
+    const index = this.tables[table].findIndex((row) => row._id === id);
+    if (index === -1) {
+      throw new Error(`Missing row: ${id}`);
+    }
+
+    this.tables[table][index] = {
+      ...this.tables[table][index],
+      ...value,
+    };
+  }
+
+  rows(table: TableName) {
+    return [...this.tables[table]];
+  }
+}
+
+function installConvexHandlerAliases() {
+  for (const fn of [
+    getAttendanceDashboard,
+    listEventAttendance,
+    recordAttendanceInsight,
+    upsertAttendanceBatch,
+  ]) {
+    const wrapped = fn as typeof fn & { handler?: unknown; _handler?: unknown };
+    if (!wrapped.handler) {
+      wrapped.handler = wrapped._handler;
+    }
+  }
+}
+
+function getHandler<TArgs, TResult>(fn: unknown) {
+  const wrapped = fn as {
+    handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+    _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+  };
+  const handler = wrapped.handler ?? wrapped._handler;
+  if (!handler) {
+    throw new Error("Convex handler is unavailable in test harness");
+  }
+  return handler;
+}
+
+async function seedEvent(db: FakeDb, overrides: Record<string, unknown> = {}) {
+  return await db.insert("events", {
+    title: "AI Forum",
+    needs_outreach: false,
+    status: "completed",
+    created_at: 1,
+    ...overrides,
+  });
+}
+
+function createHarness() {
+  installConvexHandlerAliases();
+
+  const db = new FakeDb();
+  const ctx = { db };
+
+  return { db, ctx };
+}
+
+describe("attendance state", () => {
+  test("deduplicates event attendance by normalized email and preserves earliest check-in", async () => {
+    const { db, ctx } = createHarness();
+    const eventId = await seedEvent(db, { title: "Founder Summit", event_date: "2026-04-01" });
+
+    const result = await getHandler<
+      {
+        event_id: string;
+        attendees: Array<{
+          email: string;
+          name?: string;
+          checked_in_at?: number;
+          source?: string;
+        }>;
+      },
+      {
+        processed_count: number;
+        inserted_count: number;
+        updated_count: number;
+        invalid_count: number;
+      }
+    >(upsertAttendanceBatch)(ctx as never, {
+      event_id: eventId,
+      attendees: [
+        {
+          email: " Sam@Example.com ",
+          name: "Sam Rivera",
+          checked_in_at: 200,
+          source: "manual",
+        },
+        {
+          email: "sam@example.com",
+          name: "Samuel Rivera",
+          checked_in_at: 180,
+          source: "csv_import",
+        },
+        {
+          email: "invalid-email",
+          name: "Nope",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      processed_count: 1,
+      inserted_count: 1,
+      updated_count: 0,
+      invalid_count: 1,
+    });
+
+    const rows = db.rows("attendance");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      email: "sam@example.com",
+      name: "Samuel Rivera",
+      checked_in_at: 180,
+      source: "csv_import",
+    });
+
+    await getHandler<
+      {
+        event_id: string;
+        attendees: Array<{
+          email: string;
+          name?: string;
+          checked_in_at?: number;
+          source?: string;
+        }>;
+      },
+      unknown
+    >(upsertAttendanceBatch)(ctx as never, {
+      event_id: eventId,
+      attendees: [
+        {
+          email: "sam@example.com",
+          name: "Sam Rivera",
+          checked_in_at: 250,
+          source: "manual",
+        },
+      ],
+    });
+
+    expect(db.rows("attendance")).toHaveLength(1);
+    expect(db.rows("attendance")[0]).toMatchObject({
+      email: "sam@example.com",
+      name: "Sam Rivera",
+      checked_in_at: 180,
+      source: "manual",
+    });
+  });
+
+  test("builds dashboard summaries including repeats and latest insight", async () => {
+    const { db, ctx } = createHarness();
+    const eventA = await seedEvent(db, {
+      title: "Founder Summit",
+      event_date: "2026-04-01",
+      created_at: 1,
+    });
+    const eventB = await seedEvent(db, {
+      title: "AI Fireside",
+      event_date: "2026-04-20",
+      created_at: 2,
+    });
+
+    await db.insert("attendance", {
+      event_id: eventA,
+      email: "sam@example.com",
+      name: "Sam Rivera",
+      checked_in_at: 100,
+      source: "manual",
+    });
+    await db.insert("attendance", {
+      event_id: eventA,
+      email: "lee@example.com",
+      name: "Lee Chen",
+      checked_in_at: 110,
+      source: "csv_import",
+    });
+    await db.insert("attendance", {
+      event_id: eventB,
+      email: "sam@example.com",
+      name: "Sam Rivera",
+      checked_in_at: 220,
+      source: "manual",
+    });
+    await db.insert("attendance_insights", {
+      generated_at: 300,
+      insight_text: "Repeat attendance is increasing.",
+      data_snapshot: "{\"sample\":true}",
+      event_count: 2,
+      attendee_count: 2,
+    });
+
+    const dashboard = await getHandler<{}, any>(getAttendanceDashboard)(ctx as never, {});
+
+    expect(dashboard.totals).toMatchObject({
+      events_tracked: 2,
+      unique_attendees: 2,
+      total_check_ins: 3,
+      latest_check_in_at: 220,
+    });
+    expect(dashboard.totals.by_source).toEqual({
+      manual: 2,
+      csv_import: 1,
+    });
+    expect(dashboard.event_breakdown.map((event: any) => event.title)).toEqual([
+      "Founder Summit",
+      "AI Fireside",
+    ]);
+    expect(dashboard.repeat_attendees).toEqual([
+      {
+        email: "sam@example.com",
+        name: "Sam Rivera",
+        event_count: 2,
+        latest_check_in_at: 220,
+      },
+    ]);
+    expect(dashboard.recent_attendance[0]).toMatchObject({
+      event_title: "AI Fireside",
+      email: "sam@example.com",
+    });
+    expect(dashboard.latest_insight).toMatchObject({
+      insight_text: "Repeat attendance is increasing.",
+      event_count: 2,
+      attendee_count: 2,
+    });
+  });
+
+  test("records append-only attendance insights from current dashboard counts", async () => {
+    const { db, ctx } = createHarness();
+    const eventId = await seedEvent(db, {
+      title: "Workshop Night",
+      event_date: "2026-05-01",
+    });
+
+    await db.insert("attendance", {
+      event_id: eventId,
+      email: "jules@example.com",
+      name: "Jules Park",
+      checked_in_at: 410,
+      source: "manual",
+    });
+
+    const insightId = await getHandler<
+      { insight_text: string; data_snapshot?: string },
+      string
+    >(recordAttendanceInsight)(ctx as never, {
+      insight_text: "Small-format events are converting cleanly.",
+    });
+
+    expect(insightId).toBe("attendance_insights:1");
+    expect(db.rows("attendance_insights")).toHaveLength(1);
+    expect(db.rows("attendance_insights")[0]).toMatchObject({
+      insight_text: "Small-format events are converting cleanly.",
+      event_count: 1,
+      attendee_count: 1,
+    });
+  });
+});

--- a/fe+convex/convex/attendance.ts
+++ b/fe+convex/convex/attendance.ts
@@ -1,0 +1,345 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
+
+type AttendanceRow = Doc<"attendance">;
+
+type AttendanceInput = {
+  email: string;
+  name?: string;
+  checked_in_at?: number;
+  source?: string;
+};
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function cleanOptionalText(value?: string) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isValidEmail(email: string) {
+  return email.includes("@") && !email.startsWith("@") && !email.endsWith("@");
+}
+
+function mergeAttendanceInput(previous: AttendanceInput, next: AttendanceInput): AttendanceInput {
+  return {
+    email: previous.email,
+    name: cleanOptionalText(next.name) ?? cleanOptionalText(previous.name),
+    checked_in_at: Math.min(
+      previous.checked_in_at ?? Number.MAX_SAFE_INTEGER,
+      next.checked_in_at ?? Number.MAX_SAFE_INTEGER
+    ),
+    source: cleanOptionalText(next.source) ?? cleanOptionalText(previous.source),
+  };
+}
+
+function normalizeAttendanceBatch(attendees: AttendanceInput[], now: number) {
+  const deduped = new Map<string, AttendanceInput>();
+  let invalid_count = 0;
+
+  for (const attendee of attendees) {
+    const email = normalizeEmail(attendee.email);
+    if (!isValidEmail(email)) {
+      invalid_count += 1;
+      continue;
+    }
+
+    const normalized: AttendanceInput = {
+      email,
+      name: cleanOptionalText(attendee.name),
+      checked_in_at: attendee.checked_in_at ?? now,
+      source: cleanOptionalText(attendee.source),
+    };
+
+    const existing = deduped.get(email);
+    deduped.set(email, existing ? mergeAttendanceInput(existing, normalized) : normalized);
+  }
+
+  return {
+    attendees: [...deduped.values()].map((attendee) => ({
+      ...attendee,
+      checked_in_at:
+        attendee.checked_in_at === Number.MAX_SAFE_INTEGER ? now : attendee.checked_in_at,
+    })),
+    invalid_count,
+  };
+}
+
+function summarizeSourceCounts(rows: AttendanceRow[]) {
+  return rows.reduce<Record<string, number>>((summary, row) => {
+    const key = row.source ?? "unknown";
+    summary[key] = (summary[key] ?? 0) + 1;
+    return summary;
+  }, {});
+}
+
+async function buildAttendanceDashboard(ctx: { db: { query: (table: "events" | "attendance" | "attendance_insights") => { collect: () => Promise<any[]> } } }) {
+  const [events, attendanceRows, insightRows] = await Promise.all([
+    ctx.db.query("events").collect(),
+    ctx.db.query("attendance").collect(),
+    ctx.db.query("attendance_insights").collect(),
+  ]);
+
+  const eventMap = new Map(events.map((event) => [event._id, event]));
+  const eventBuckets = new Map<
+    Id<"events">,
+    {
+      event_id: Id<"events">;
+      title: string;
+      event_date: string | null;
+      attendee_count: number;
+      latest_check_in_at: number | null;
+      sources: Record<string, number>;
+    }
+  >();
+  const attendeeMap = new Map<
+    string,
+    {
+      email: string;
+      name: string | null;
+      event_ids: Set<Id<"events">>;
+      latest_check_in_at: number;
+    }
+  >();
+
+  for (const row of attendanceRows as AttendanceRow[]) {
+    const event = eventMap.get(row.event_id);
+    if (!event) continue;
+
+    const eventBucket = eventBuckets.get(row.event_id) ?? {
+      event_id: row.event_id,
+      title: event.title,
+      event_date: event.event_date ?? null,
+      attendee_count: 0,
+      latest_check_in_at: null,
+      sources: {} as Record<string, number>,
+    };
+    eventBucket.attendee_count += 1;
+    eventBucket.latest_check_in_at = Math.max(
+      eventBucket.latest_check_in_at ?? 0,
+      row.checked_in_at
+    );
+    eventBucket.sources[row.source ?? "unknown"] =
+      (eventBucket.sources[row.source ?? "unknown"] ?? 0) + 1;
+    eventBuckets.set(row.event_id, eventBucket);
+
+    const attendeeBucket = attendeeMap.get(row.email) ?? {
+      email: row.email,
+      name: row.name ?? null,
+      event_ids: new Set<Id<"events">>(),
+      latest_check_in_at: row.checked_in_at,
+    };
+    attendeeBucket.name = row.name ?? attendeeBucket.name;
+    attendeeBucket.event_ids.add(row.event_id);
+    attendeeBucket.latest_check_in_at = Math.max(
+      attendeeBucket.latest_check_in_at,
+      row.checked_in_at
+    );
+    attendeeMap.set(row.email, attendeeBucket);
+  }
+
+  const latestInsight = [...insightRows]
+    .sort((a, b) => b.generated_at - a.generated_at)[0] ?? null;
+  const recentAttendance = [...attendanceRows]
+    .sort((a, b) => b.checked_in_at - a.checked_in_at)
+    .slice(0, 12)
+    .map((row) => {
+      const event = eventMap.get(row.event_id);
+      return {
+        _id: row._id,
+        event_id: row.event_id,
+        event_title: event?.title ?? "Unknown event",
+        event_date: event?.event_date ?? null,
+        email: row.email,
+        name: row.name ?? null,
+        checked_in_at: row.checked_in_at,
+        source: row.source ?? null,
+      };
+    });
+
+  const eventBreakdown = [...eventBuckets.values()].sort((a, b) => {
+    if (b.attendee_count !== a.attendee_count) {
+      return b.attendee_count - a.attendee_count;
+    }
+    return (b.latest_check_in_at ?? 0) - (a.latest_check_in_at ?? 0);
+  });
+
+  const repeatAttendees = [...attendeeMap.values()]
+    .map((attendee) => ({
+      email: attendee.email,
+      name: attendee.name,
+      event_count: attendee.event_ids.size,
+      latest_check_in_at: attendee.latest_check_in_at,
+    }))
+    .filter((attendee) => attendee.event_count > 1)
+    .sort((a, b) => {
+      if (b.event_count !== a.event_count) {
+        return b.event_count - a.event_count;
+      }
+      return b.latest_check_in_at - a.latest_check_in_at;
+    })
+    .slice(0, 8);
+
+  return {
+    totals: {
+      events_tracked: eventBreakdown.length,
+      unique_attendees: attendeeMap.size,
+      total_check_ins: attendanceRows.length,
+      latest_check_in_at: recentAttendance[0]?.checked_in_at ?? null,
+      by_source: summarizeSourceCounts(attendanceRows as AttendanceRow[]),
+    },
+    event_breakdown: eventBreakdown,
+    repeat_attendees: repeatAttendees,
+    recent_attendance: recentAttendance,
+    latest_insight: latestInsight
+      ? {
+          _id: latestInsight._id,
+          generated_at: latestInsight.generated_at,
+          insight_text: latestInsight.insight_text,
+          data_snapshot: latestInsight.data_snapshot ?? null,
+          event_count: latestInsight.event_count,
+          attendee_count: latestInsight.attendee_count,
+        }
+      : null,
+  };
+}
+
+export const upsertAttendanceBatch = mutation({
+  args: {
+    event_id: v.id("events"),
+    attendees: v.array(
+      v.object({
+        email: v.string(),
+        name: v.optional(v.string()),
+        checked_in_at: v.optional(v.number()),
+        source: v.optional(v.string()),
+      })
+    ),
+  },
+  handler: async (ctx, { event_id, attendees }) => {
+    const event = await ctx.db.get(event_id);
+    if (!event) {
+      throw new Error(`Event not found: ${event_id}`);
+    }
+
+    const now = Date.now();
+    const { attendees: normalized, invalid_count } = normalizeAttendanceBatch(attendees, now);
+    let inserted_count = 0;
+    let updated_count = 0;
+
+    for (const attendee of normalized) {
+      const existing = await ctx.db
+        .query("attendance")
+        .withIndex("by_event_email", (q) =>
+          q.eq("event_id", event_id).eq("email", attendee.email)
+        )
+        .unique();
+
+      if (!existing) {
+        await ctx.db.insert("attendance", {
+          event_id,
+          email: attendee.email,
+          name: attendee.name,
+          checked_in_at: attendee.checked_in_at ?? now,
+          source: attendee.source,
+        });
+        inserted_count += 1;
+        continue;
+      }
+
+      const nextName = attendee.name ?? existing.name;
+      const nextSource = attendee.source ?? existing.source;
+      const nextCheckedInAt = Math.min(
+        existing.checked_in_at,
+        attendee.checked_in_at ?? existing.checked_in_at
+      );
+
+      if (
+        nextName !== existing.name ||
+        nextSource !== existing.source ||
+        nextCheckedInAt !== existing.checked_in_at
+      ) {
+        await ctx.db.patch(existing._id, {
+          name: nextName,
+          source: nextSource,
+          checked_in_at: nextCheckedInAt,
+        });
+        updated_count += 1;
+      }
+    }
+
+    return {
+      event_id,
+      event_title: event.title,
+      processed_count: normalized.length,
+      inserted_count,
+      updated_count,
+      invalid_count,
+    };
+  },
+});
+
+export const listEventAttendance = query({
+  args: { event_id: v.id("events") },
+  handler: async (ctx, { event_id }) => {
+    const event = await ctx.db.get(event_id);
+    if (!event) {
+      throw new Error(`Event not found: ${event_id}`);
+    }
+
+    const attendees = await ctx.db
+      .query("attendance")
+      .withIndex("by_event_id", (q) => q.eq("event_id", event_id))
+      .collect();
+
+    return {
+      event: {
+        _id: event._id,
+        title: event.title,
+        event_date: event.event_date ?? null,
+      },
+      attendees: attendees.sort((a, b) => b.checked_in_at - a.checked_in_at),
+    };
+  },
+});
+
+export const getAttendanceDashboard = query({
+  args: {},
+  handler: async (ctx) => {
+    return await buildAttendanceDashboard(ctx);
+  },
+});
+
+export const recordAttendanceInsight = mutation({
+  args: {
+    insight_text: v.string(),
+    data_snapshot: v.optional(v.string()),
+  },
+  handler: async (ctx, { insight_text, data_snapshot }) => {
+    const trimmedInsight = insight_text.trim();
+    if (!trimmedInsight) {
+      throw new Error("Insight text is required");
+    }
+
+    const dashboard = await buildAttendanceDashboard(ctx);
+    const generated_at = Date.now();
+    const snapshot =
+      data_snapshot ??
+      JSON.stringify({
+        totals: dashboard.totals,
+        event_breakdown: dashboard.event_breakdown.slice(0, 5),
+        repeat_attendees: dashboard.repeat_attendees.slice(0, 5),
+      });
+
+    return await ctx.db.insert("attendance_insights", {
+      generated_at,
+      insight_text: trimmedInsight,
+      data_snapshot: snapshot,
+      event_count: dashboard.totals.events_tracked,
+      attendee_count: dashboard.totals.unique_attendees,
+    });
+  },
+});

--- a/fe+convex/convex/schema.ts
+++ b/fe+convex/convex/schema.ts
@@ -41,6 +41,25 @@ export default defineSchema({
     .index("by_attio_record_id", ["attio_record_id"])
     .index("by_event_attio", ["event_id", "attio_record_id"]),
 
+  attendance: defineTable({
+    event_id: v.id("events"),
+    email: v.string(),
+    name: v.optional(v.string()),
+    checked_in_at: v.number(),
+    source: v.optional(v.string()),
+  })
+    .index("by_event_id", ["event_id"])
+    .index("by_email", ["email"])
+    .index("by_event_email", ["event_id", "email"]),
+
+  attendance_insights: defineTable({
+    generated_at: v.number(),
+    insight_text: v.string(),
+    data_snapshot: v.optional(v.string()),
+    event_count: v.number(),
+    attendee_count: v.number(),
+  }).index("by_generated_at", ["generated_at"]),
+
   agent_threads: defineTable({
     external_id: v.string(),
     channel: v.string(),

--- a/fe+convex/tsconfig.json
+++ b/fe+convex/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "types": ["bun-types"],
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
@@ -26,8 +27,6 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- restore `attendance` and `attendance_insights` to the Convex schema
- add attendance queries and mutations for batch upsert, dashboard aggregates, and insight snapshots
- add `/dashboard/data` with attendance KPIs, event breakdowns, repeat attendees, recent check-ins, and manual seeding controls
- update dashboard navigation and align `PLAN.md` + `AGENTS.md` with the restored attendance contract

## Verification
- `bun test convex/attendance.test.ts`
- `bunx tsc -p convex/tsconfig.json`
- `bunx tsc -p tsconfig.json`
- `npx convex codegen`

## Notes
- `bunx next build` could not complete in the sandbox because `next/font` tried to fetch Google Fonts while network access was blocked