### PR TITLE
feat(traces): Normalized reasoning-trace pipeline (Issue #20)

### DIFF
--- a/agent/runtime/contracts.py
+++ b/agent/runtime/contracts.py
@@ -31,6 +31,21 @@ class ApprovalStatus(str, Enum):
     REJECTED = "rejected"
 
 
+class TraceStepKind(str, Enum):
+    PLANNING = "planning"
+    TOOL_SELECTION = "tool_selection"
+    TOOL_START = "tool_start"
+    TOOL_COMPLETION = "tool_completion"
+    TOOL_FAILURE = "tool_failure"
+    APPROVAL_PAUSE = "approval_pause"
+    APPROVAL_RESOLUTION = "approval_resolution"
+    ARTIFACT_GENERATION = "artifact_generation"
+    THINKING = "thinking"
+    GUARDRAIL_RETRY = "guardrail_retry"
+    RUN_COMPLETED = "run_completed"
+    RUN_ERROR = "run_error"
+
+
 class ArtifactKind(str, Enum):
     METRIC_GROUP = "metric_group"
     TABLE = "table"
@@ -142,6 +157,21 @@ class ArtifactRecord(BaseModel):
     updated_at: int
 
 
+class TraceStepRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    run_external_id: str
+    kind: TraceStepKind
+    sequence_number: int
+    summary: str
+    detail_json: str | None = None
+    status: str = "completed"
+    created_at: int
+    updated_at: int
+
+
 class ApprovalRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -210,6 +240,7 @@ class ThreadStateResponse(BaseModel):
     artifacts: list[ArtifactRecord]
     approvals: list[ApprovalRecord]
     context_links: list[ContextLinkRecord]
+    traces: list[TraceStepRecord] = Field(default_factory=list)
 
 
 class RunWithEventsResponse(BaseModel):
@@ -217,6 +248,7 @@ class RunWithEventsResponse(BaseModel):
 
     run: RunRecord
     events: list[StreamEvent]
+    traces: list[TraceStepRecord] = Field(default_factory=list)
 
 
 class ApprovalDecisionResponse(BaseModel):

--- a/agent/runtime/convex_sync.py
+++ b/agent/runtime/convex_sync.py
@@ -14,6 +14,7 @@ from .contracts import (
     MessageRecord,
     RunRecord,
     ThreadRecord,
+    TraceStepRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -198,6 +199,34 @@ class ConvexAgentStateSync:
                 return await sb.mutation("agentState:resolveApproval", args)
         except Exception as exc:
             logger.warning("Convex approval resolve sync failed: %s", exc)
+            return None
+
+    async def append_trace(self, record: TraceStepRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        run_convex_id = await self._ensure_run_convex_id(record.run_external_id)
+        if not thread_convex_id or not run_convex_id:
+            return None
+
+        args = {
+            "thread_id": thread_convex_id,
+            "run_id": run_convex_id,
+            "external_id": record.external_id,
+            "kind": record.kind.value,
+            "sequence_number": record.sequence_number,
+            "summary": record.summary,
+            "detail_json": record.detail_json,
+            "status": record.status,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        try:
+            async with ConvexClient() as sb:
+                return await sb.mutation("agentState:appendTrace", args)
+        except Exception as exc:
+            logger.warning("Convex trace sync failed: %s", exc)
             return None
 
     async def upsert_context_link(self, thread_external_id: str, record: ContextLinkRecord, run_external_id: str | None = None) -> str | None:

--- a/agent/runtime/normalize.py
+++ b/agent/runtime/normalize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Iterable
 
-from .contracts import ArtifactKind, ArtifactRecord, ContentBlock, StreamEvent
+from .contracts import ArtifactKind, ArtifactRecord, ContentBlock, StreamEvent, TraceStepKind, TraceStepRecord
 
 
 def now_ms() -> int:
@@ -49,6 +49,32 @@ def make_report_artifact(
             text_block(report_text, label="body"),
             json_block("report_meta", {"source": "modal_runtime"}, label="meta"),
         ],
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def make_trace_step(
+    *,
+    external_id: str,
+    thread_id: str,
+    run_id: str,
+    kind: TraceStepKind,
+    sequence_number: int,
+    summary: str,
+    detail_json: str | None = None,
+    status: str = "completed",
+) -> TraceStepRecord:
+    created_at = now_ms()
+    return TraceStepRecord(
+        external_id=external_id,
+        thread_external_id=thread_id,
+        run_external_id=run_id,
+        kind=kind,
+        sequence_number=sequence_number,
+        summary=summary,
+        detail_json=detail_json,
+        status=status,
         created_at=created_at,
         updated_at=created_at,
     )

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -22,9 +22,11 @@ from .contracts import (
     ThreadCreateRequest,
     ThreadRecord,
     ThreadStateResponse,
+    TraceStepKind,
+    TraceStepRecord,
 )
 from .convex_sync import ConvexAgentStateSync
-from .normalize import make_report_artifact, text_block
+from .normalize import make_report_artifact, make_trace_step, text_block
 from .policy import ApprovalPolicy, ToolAction, infer_tool_action_from_text
 from .store import InMemoryRuntimeStore
 from .tool_expectations import (
@@ -131,6 +133,8 @@ class AgentRuntimeService:
             await self._store.upsert_approval(approval)
         for link in hydrated.context_links:
             await self._store.put_context_link(link)
+        for trace in hydrated.traces:
+            await self._store.append_trace(trace)
 
         return hydrated
 
@@ -163,6 +167,14 @@ class AgentRuntimeService:
             data={"status": run.status.value},
         )
 
+        # Emit planning trace step
+        await self._emit_trace(
+            thread_id=request.thread_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.PLANNING,
+            summary="Analyzing request and planning execution strategy.",
+        )
+
         await self._append_message(
             thread_id=request.thread_id,
             run_id=run.external_id,
@@ -176,7 +188,8 @@ class AgentRuntimeService:
         if not resolved:
             raise HTTPException(status_code=500, detail="Run state missing after execution")
         events = await self._store.list_stream_events(run.external_id)
-        return RunWithEventsResponse(run=resolved, events=events)
+        traces = await self._store.list_traces_for_run(run.external_id)
+        return RunWithEventsResponse(run=resolved, events=events, traces=traces)
 
     async def submit_approval(self, approval_id: str, request: ApprovalDecisionRequest) -> ApprovalDecisionResponse:
         decision_status = ApprovalStatus(request.decision)
@@ -210,6 +223,15 @@ class AgentRuntimeService:
             data={"approval_id": approval.external_id, "decision": approval.status.value},
         )
 
+        # Emit approval resolution trace
+        await self._emit_trace(
+            thread_id=approval.thread_external_id,
+            run_id=approval.run_external_id,
+            kind=TraceStepKind.APPROVAL_RESOLUTION,
+            summary=f"Approval {approval.status.value}: {approval.title}",
+            detail_json=json.dumps({"decision": approval.status.value, "note": request.note}),
+        )
+
         run = await self._store.get_run(approval.run_external_id)
         if not run:
             raise HTTPException(status_code=500, detail="Run missing for approval")
@@ -238,6 +260,12 @@ class AgentRuntimeService:
                 created_at=now,
                 data={"status": run.status.value},
             )
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.RUN_COMPLETED,
+                summary="Run completed: action was rejected by user.",
+            )
             return ApprovalDecisionResponse(approval=approval, run=run)
 
         pending_action = await self._store.pop_pending_action(run.external_id)
@@ -261,9 +289,23 @@ class AgentRuntimeService:
         tool_payload = pending_action.payload.get("tool_input") if pending_action else None
         tool_result: object | None = None
         if isinstance(tool_payload, dict):
+            # Emit tool start trace
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.TOOL_START,
+                summary=f"Executing approved tool: {action_label}",
+                detail_json=json.dumps({"tool": action_label, "input": tool_payload}),
+            )
             try:
                 tool_result = await execute_tool_call(action_label, tool_payload)
             except Exception as exc:
+                await self._emit_trace(
+                    thread_id=run.thread_external_id,
+                    run_id=run.external_id,
+                    kind=TraceStepKind.TOOL_FAILURE,
+                    summary=f"Tool {action_label} failed: {str(exc)[:200]}",
+                )
                 await self._mark_run_error(run=run, message=str(exc))
                 failed = await self._store.get_run(run.external_id)
                 if not failed:
@@ -275,6 +317,13 @@ class AgentRuntimeService:
                 event="tool.completed",
                 created_at=_now_ms(),
                 data={"name": action_label, "result": self._serialize_tool_result(tool_result)},
+            )
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.TOOL_COMPLETION,
+                summary=f"Tool {action_label} completed successfully.",
+                detail_json=json.dumps({"tool": action_label, "result": self._serialize_tool_result(tool_result)}),
             )
             await self._append_message(
                 thread_id=run.thread_external_id,
@@ -298,6 +347,15 @@ class AgentRuntimeService:
             created_at=_now_ms(),
             data={},
         )
+
+        # Emit thinking trace for post-approval summarization
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.THINKING,
+            summary="Summarizing approved action outcome.",
+        )
+
         await self._execute_text_run(
             run=run,
             user_input=(
@@ -367,6 +425,21 @@ class AgentRuntimeService:
             created_at=now,
             data={"status": run.status.value},
         )
+
+        # Emit approval pause trace
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.APPROVAL_PAUSE,
+            summary=f"Waiting for approval: {action.name}",
+            detail_json=json.dumps({
+                "action": action.name,
+                "risk_level": decision.risk_level.value,
+                "reason": decision.reason,
+            }),
+            status="waiting",
+        )
+
         return run
 
     async def _execute_run(self, *, run: RunRecord, user_input: str, max_tokens: int) -> None:
@@ -389,10 +462,25 @@ class AgentRuntimeService:
                 created_at=_now_ms(),
                 data={"name": action.name, "class": action.action_class.value},
             )
+            # Emit tool selection trace
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.TOOL_SELECTION,
+                summary=f"Selected tool: {action.name} ({action.action_class.value})",
+            )
 
         if action and self._policy.evaluate(action).requires_approval:
             await self._pause_for_approval(run=run, action=action)
             return
+
+        # Emit thinking trace for text generation
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.THINKING,
+            summary="Generating response.",
+        )
 
         await self._execute_text_run(run=run, user_input=user_input, max_tokens=max_tokens)
 
@@ -401,6 +489,12 @@ class AgentRuntimeService:
         try:
             result = await self._adapter.run_agent(user_prompt=user_input)
         except Exception as exc:
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.RUN_ERROR,
+                summary=f"Agent execution failed: {str(exc)[:200]}",
+            )
             await self._mark_run_error(run=run, message=str(exc))
             return
 
@@ -415,6 +509,14 @@ class AgentRuntimeService:
                     "kind": expectation.kind if expectation else "unknown",
                     "reason": "relevant_tools_not_used",
                 },
+            )
+            # Emit guardrail retry trace
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.GUARDRAIL_RETRY,
+                summary="Retrying: relevant tools were not used in first attempt.",
+                detail_json=json.dumps({"kind": expectation.kind if expectation else "unknown"}),
             )
             try:
                 result = await self._adapter.run_agent(
@@ -448,16 +550,41 @@ class AgentRuntimeService:
                 created_at=_now_ms(),
                 data={"name": trace.name, "input": trace.tool_input},
             )
+            # Emit tool selection trace
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.TOOL_SELECTION,
+                summary=f"Using tool: {trace.name}",
+                detail_json=json.dumps({"tool": trace.name, "input": trace.tool_input}),
+            )
             if trace.result is not None:
+                is_error = trace.is_error
                 await self._store.append_stream_event(
                     run_id=run.external_id,
-                    event="tool.completed" if not trace.is_error else "tool.failed",
+                    event="tool.completed" if not is_error else "tool.failed",
                     created_at=_now_ms(),
                     data={
                         "name": trace.name,
                         "result": self._serialize_tool_result(trace.result),
-                        "is_error": trace.is_error,
+                        "is_error": is_error,
                     },
+                )
+                # Emit tool completion/failure trace
+                await self._emit_trace(
+                    thread_id=run.thread_external_id,
+                    run_id=run.external_id,
+                    kind=TraceStepKind.TOOL_FAILURE if is_error else TraceStepKind.TOOL_COMPLETION,
+                    summary=(
+                        f"Tool {trace.name} failed: {self._tool_result_text(trace.result)[:200]}"
+                        if is_error
+                        else f"Tool {trace.name} completed."
+                    ),
+                    detail_json=json.dumps({
+                        "tool": trace.name,
+                        "result": self._serialize_tool_result(trace.result),
+                        "is_error": is_error,
+                    }),
                 )
 
         if result.blocked_action:
@@ -482,6 +609,12 @@ class AgentRuntimeService:
                     data={"text": partial_text},
                 )
         except Exception as exc:
+            await self._emit_trace(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                kind=TraceStepKind.RUN_ERROR,
+                summary=f"Text generation failed: {str(exc)[:200]}",
+            )
             await self._mark_run_error(run=run, message=str(exc))
             return
 
@@ -514,6 +647,15 @@ class AgentRuntimeService:
             data={"artifact_id": artifact.external_id, "kind": artifact.kind.value},
         )
 
+        # Emit artifact generation trace
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.ARTIFACT_GENERATION,
+            summary=f"Generated artifact: {artifact.title}",
+            detail_json=json.dumps({"artifact_id": artifact.external_id, "kind": artifact.kind.value}),
+        )
+
         now = _now_ms()
         completed = run.model_copy(
             update={
@@ -531,6 +673,14 @@ class AgentRuntimeService:
             event="run.completed",
             created_at=now,
             data={"status": completed.status.value},
+        )
+
+        # Emit run completed trace
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.RUN_COMPLETED,
+            summary="Run completed successfully.",
         )
 
     async def _mark_run_error(self, *, run: RunRecord, message: str) -> None:
@@ -551,6 +701,53 @@ class AgentRuntimeService:
             created_at=now,
             data={"message": message},
         )
+
+        # Emit run error trace
+        await self._emit_trace(
+            thread_id=run.thread_external_id,
+            run_id=run.external_id,
+            kind=TraceStepKind.RUN_ERROR,
+            summary=f"Run failed: {message[:200]}",
+        )
+
+    async def _emit_trace(
+        self,
+        *,
+        thread_id: str,
+        run_id: str,
+        kind: TraceStepKind,
+        summary: str,
+        detail_json: str | None = None,
+        status: str = "completed",
+    ) -> TraceStepRecord:
+        seq = await self._store.next_trace_sequence(run_id)
+        trace = make_trace_step(
+            external_id=f"trace_{uuid4().hex}",
+            thread_id=thread_id,
+            run_id=run_id,
+            kind=kind,
+            sequence_number=seq,
+            summary=summary,
+            detail_json=detail_json,
+            status=status,
+        )
+        await self._store.append_trace(trace)
+        await self._sync.append_trace(trace)
+
+        # Also emit as a stream event so live consumers see it
+        await self._store.append_stream_event(
+            run_id=run_id,
+            event="trace.step",
+            created_at=trace.created_at,
+            data={
+                "trace_id": trace.external_id,
+                "kind": kind.value,
+                "summary": summary,
+                "status": status,
+                "sequence": seq,
+            },
+        )
+        return trace
 
     async def _append_message(
         self,
@@ -692,6 +889,23 @@ class AgentRuntimeService:
             if isinstance(item, dict)
         ]
 
+        traces = [
+            TraceStepRecord(
+                external_id=str(item.get("external_id")),
+                thread_external_id=thread.external_id,
+                run_external_id=str(item.get("run_external_id", item.get("run_id", ""))),
+                kind=item.get("kind", "thinking"),
+                sequence_number=item.get("sequence_number", 0),
+                summary=item.get("summary", ""),
+                detail_json=item.get("detail_json"),
+                status=item.get("status", "completed"),
+                created_at=item.get("created_at") or _now_ms(),
+                updated_at=item.get("updated_at") or _now_ms(),
+            )
+            for item in state.get("traces", [])
+            if isinstance(item, dict)
+        ]
+
         return ThreadStateResponse(
             thread=thread,
             runs=runs,
@@ -699,6 +913,7 @@ class AgentRuntimeService:
             artifacts=artifacts,
             approvals=approvals,
             context_links=context_links,
+            traces=traces,
         )
 
     def _hydrate_thread_record(self, item: dict) -> ThreadRecord:

--- a/agent/runtime/store.py
+++ b/agent/runtime/store.py
@@ -13,6 +13,7 @@ from .contracts import (
     StreamEvent,
     ThreadRecord,
     ThreadStateResponse,
+    TraceStepRecord,
 )
 from .policy import ToolAction
 
@@ -33,6 +34,8 @@ class InMemoryRuntimeStore:
         self._run_event_sequences: dict[str, int] = defaultdict(int)
         self._run_events: dict[str, list[StreamEvent]] = defaultdict(list)
         self._pending_actions: dict[str, ToolAction] = {}
+        self._trace_sequences: dict[str, int] = defaultdict(int)
+        self.traces: dict[str, TraceStepRecord] = {}
         self._thread_insert_counter = 0
         self._thread_insert_order: dict[str, int] = {}
 
@@ -122,6 +125,25 @@ class InMemoryRuntimeStore:
         events = self._run_events.get(run_id, [])
         return [event for event in events if event.sequence > after_sequence]
 
+    async def append_trace(self, record: TraceStepRecord) -> None:
+        async with self._lock:
+            self.traces[record.external_id] = record
+
+    async def next_trace_sequence(self, run_id: str) -> int:
+        async with self._lock:
+            self._trace_sequences[run_id] += 1
+            return self._trace_sequences[run_id]
+
+    async def list_traces_for_run(self, run_id: str) -> list[TraceStepRecord]:
+        traces = [t for t in self.traces.values() if t.run_external_id == run_id]
+        traces.sort(key=lambda t: t.sequence_number)
+        return traces
+
+    async def list_traces_for_thread(self, thread_id: str) -> list[TraceStepRecord]:
+        traces = [t for t in self.traces.values() if t.thread_external_id == thread_id]
+        traces.sort(key=lambda t: (t.run_external_id, t.sequence_number))
+        return traces
+
     async def list_thread_state(self, thread_id: str) -> ThreadStateResponse | None:
         thread = self.threads.get(thread_id)
         if not thread:
@@ -139,6 +161,9 @@ class InMemoryRuntimeStore:
         approvals.sort(key=lambda row: row.requested_at, reverse=True)
         context_links.sort(key=lambda row: row.created_at)
 
+        traces = [row for row in self.traces.values() if row.thread_external_id == thread_id]
+        traces.sort(key=lambda row: (row.run_external_id, row.sequence_number))
+
         return ThreadStateResponse(
             thread=thread,
             runs=runs,
@@ -146,4 +171,5 @@ class InMemoryRuntimeStore:
             artifacts=artifacts,
             approvals=approvals,
             context_links=context_links,
+            traces=traces,
         )

--- a/agent/tests/test_runtime_traces.py
+++ b/agent/tests/test_runtime_traces.py
@@ -1,0 +1,694 @@
+"""
+Tests for the normalized reasoning-trace system (Issue #20).
+
+Success / Failure States
+========================
+
+SUCCESS states:
+  - Every completed run emits at least a PLANNING trace and a RUN_COMPLETED trace.
+  - Tool-aware runs emit TOOL_SELECTION and TOOL_COMPLETION/TOOL_FAILURE traces
+    for each tool invocation.
+  - Approval-paused runs emit an APPROVAL_PAUSE trace with status="waiting".
+  - After approval resolution, an APPROVAL_RESOLUTION trace is emitted.
+  - Guardrail retries produce a GUARDRAIL_RETRY trace.
+  - Traces are returned in RunWithEventsResponse.traces and ThreadStateResponse.traces.
+  - Traces are ordered by (run_id, sequence_number) ascending.
+  - Each trace has a unique external_id and monotonically increasing sequence_number per run.
+  - Trace detail_json (when present) is valid JSON.
+  - No trace contains raw provider payloads (no "anthropic", no "provider_event").
+
+FAILURE states:
+  - A run that errors emits a RUN_ERROR trace.
+  - Missing or out-of-order traces indicate a regression in the emit pipeline.
+  - Traces with invalid JSON in detail_json indicate serialization bugs.
+  - If a completed run has zero traces, the trace pipeline is broken.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+import runtime.service as runtime_service
+from runtime.anthropic_adapter import AgentTurnResult, ToolTrace
+from runtime.contracts import (
+    ApprovalDecisionRequest,
+    ApprovalStatus,
+    RunCreateRequest,
+    ThreadCreateRequest,
+    TraceStepKind,
+)
+from runtime.policy import ActionClass, ApprovalPolicy, ToolAction
+from runtime.service import AgentRuntimeService
+from runtime.store import InMemoryRuntimeStore
+
+
+# ---------------------------------------------------------------------------
+# Fake adapters (reused from test_runtime_service.py pattern)
+# ---------------------------------------------------------------------------
+
+class FakeAdapter:
+    model = "fake-model"
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        _ = (system_prompt, max_tokens)
+        yield f"Processed: {user_prompt[:20]}"
+        yield f"Processed: {user_prompt[:20]} complete"
+
+
+class FakeToolAwareAdapter:
+    model = "fake-agent-sdk"
+
+    def __init__(self, result: AgentTurnResult | list[AgentTurnResult]) -> None:
+        if isinstance(result, list):
+            self._results = list(result)
+        else:
+            self._results = [result]
+        self.calls: list[dict[str, object]] = []
+
+    async def run_agent(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_turns: int = 6,
+    ) -> AgentTurnResult:
+        self.calls.append(
+            {
+                "user_prompt": user_prompt,
+                "system_prompt": system_prompt,
+                "max_turns": max_turns,
+            }
+        )
+        return self._results.pop(0)
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        _ = (user_prompt, system_prompt, max_tokens)
+        yield "Approved tool executed"
+        yield "Approved tool executed successfully"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _trace_kinds(traces) -> list[str]:
+    """Extract the kind values from a list of TraceStepRecord objects."""
+    return [t.kind.value if hasattr(t.kind, "value") else t.kind for t in traces]
+
+
+def _assert_valid_detail_json(traces) -> None:
+    """Assert that every trace with detail_json has valid JSON content."""
+    for t in traces:
+        if t.detail_json:
+            parsed = json.loads(t.detail_json)
+            assert isinstance(parsed, dict), f"detail_json should be a dict, got {type(parsed)}"
+
+
+def _assert_no_provider_leak(traces) -> None:
+    """Assert that no trace leaks raw provider payloads."""
+    for t in traces:
+        combined = t.summary + (t.detail_json or "")
+        assert "provider_event" not in combined, f"Trace {t.external_id} leaks provider_event"
+
+
+def _assert_monotonic_sequences(traces) -> None:
+    """Assert that sequence numbers are monotonically increasing per run."""
+    by_run: dict[str, list[int]] = {}
+    for t in traces:
+        by_run.setdefault(t.run_external_id, []).append(t.sequence_number)
+    for run_id, seqs in by_run.items():
+        assert seqs == sorted(seqs), f"Traces for run {run_id} are not in order: {seqs}"
+        assert len(seqs) == len(set(seqs)), f"Duplicate sequence numbers in run {run_id}: {seqs}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Basic text run traces
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_simple_text_run_emits_planning_and_completed_traces() -> None:
+    """SUCCESS: A simple text run produces PLANNING, THINKING, ARTIFACT_GENERATION, and RUN_COMPLETED traces."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Summarize the agenda")
+    )
+
+    assert response.run.status.value == "completed"
+
+    traces = response.traces
+    assert len(traces) >= 3, f"Expected at least 3 traces, got {len(traces)}"
+
+    kinds = _trace_kinds(traces)
+    assert "planning" in kinds, "Missing PLANNING trace"
+    assert "run_completed" in kinds, "Missing RUN_COMPLETED trace"
+    assert "artifact_generation" in kinds, "Missing ARTIFACT_GENERATION trace"
+
+    _assert_monotonic_sequences(traces)
+    _assert_valid_detail_json(traces)
+    _assert_no_provider_leak(traces)
+
+
+@pytest.mark.asyncio
+async def test_traces_appear_in_thread_state() -> None:
+    """SUCCESS: Traces are persisted and returned in ThreadStateResponse."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="State test"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Hello")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    assert len(state.traces) >= 3, f"Expected traces in thread state, got {len(state.traces)}"
+
+    kinds = _trace_kinds(state.traces)
+    assert "planning" in kinds
+    assert "run_completed" in kinds
+
+
+@pytest.mark.asyncio
+async def test_trace_unique_external_ids() -> None:
+    """SUCCESS: Every trace has a unique external_id."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Unique ID test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Test uniqueness")
+    )
+
+    ids = [t.external_id for t in response.traces]
+    assert len(ids) == len(set(ids)), f"Duplicate trace IDs found: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tool-aware run traces
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tool_aware_read_run_emits_tool_traces() -> None:
+    """SUCCESS: A tool-aware read run emits TOOL_SELECTION and TOOL_COMPLETION traces."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Checking dashboard", "Summary ready"],
+                final_text="Summary ready",
+                tool_traces=[
+                    ToolTrace(
+                        name="get_attendance_dashboard",
+                        tool_input={},
+                        tool_use_id="tool_1",
+                        result={"totals": {"events_tracked": 2}},
+                    )
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Tool trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="How is attendance?")
+    )
+
+    assert response.run.status.value == "completed"
+
+    kinds = _trace_kinds(response.traces)
+    assert "planning" in kinds
+    assert "tool_selection" in kinds, "Missing TOOL_SELECTION trace"
+    assert "tool_completion" in kinds, "Missing TOOL_COMPLETION trace"
+    assert "run_completed" in kinds
+
+    # Verify tool detail_json contains tool name
+    tool_traces = [t for t in response.traces if t.kind.value == "tool_selection"]
+    assert len(tool_traces) >= 1
+    detail = json.loads(tool_traces[0].detail_json)
+    assert detail["tool"] == "get_attendance_dashboard"
+
+    _assert_valid_detail_json(response.traces)
+    _assert_no_provider_leak(response.traces)
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_emits_tool_failure_trace() -> None:
+    """SUCCESS: A failed tool produces a TOOL_FAILURE trace."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Error occurred"],
+                final_text="Tool failed.",
+                tool_traces=[
+                    ToolTrace(
+                        name="list_events",
+                        tool_input={"limit": 5},
+                        tool_use_id="tool_1",
+                        result="convex timeout",
+                        is_error=True,
+                    )
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Failure trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="What are the latest stats?")
+    )
+
+    kinds = _trace_kinds(response.traces)
+    assert "tool_failure" in kinds, "Missing TOOL_FAILURE trace"
+
+    failure_traces = [t for t in response.traces if t.kind.value == "tool_failure"]
+    assert "list_events" in failure_traces[0].summary
+
+
+# ---------------------------------------------------------------------------
+# Tests: Approval flow traces
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_approval_pause_emits_trace() -> None:
+    """SUCCESS: A run paused for approval emits an APPROVAL_PAUSE trace with status='waiting'."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Approval trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Send outreach email to speakers")
+    )
+
+    assert response.run.status.value == "paused_approval"
+
+    kinds = _trace_kinds(response.traces)
+    assert "planning" in kinds
+    assert "approval_pause" in kinds, "Missing APPROVAL_PAUSE trace"
+
+    pause_traces = [t for t in response.traces if t.kind.value == "approval_pause"]
+    assert pause_traces[0].status == "waiting"
+
+    _assert_valid_detail_json(response.traces)
+
+
+@pytest.mark.asyncio
+async def test_approval_resolution_emits_trace() -> None:
+    """SUCCESS: Resolving an approval emits APPROVAL_RESOLUTION and RUN_COMPLETED traces."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Resolution trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Delete this event")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    approval = state.approvals[0]
+
+    decision = await service.submit_approval(
+        approval.external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.REJECTED),
+    )
+
+    assert decision.run.status.value == "completed"
+
+    # Get all traces after resolution
+    full_state = await service.get_thread_state(thread.external_id)
+    kinds = _trace_kinds(full_state.traces)
+    assert "approval_resolution" in kinds, "Missing APPROVAL_RESOLUTION trace"
+    assert "run_completed" in kinds, "Missing RUN_COMPLETED trace"
+
+    _assert_valid_detail_json(full_state.traces)
+
+
+@pytest.mark.asyncio
+async def test_approved_write_tool_emits_tool_start_and_completion_traces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SUCCESS: Approving a write tool emits TOOL_START, TOOL_COMPLETION, and APPROVAL_RESOLUTION traces."""
+    executed: list[tuple[str, dict]] = []
+
+    async def fake_execute_tool_call(tool_name: str, tool_input: dict) -> dict:
+        executed.append((tool_name, tool_input))
+        return {"_id": tool_input["event_id"], "status": tool_input["status"]}
+
+    monkeypatch.setattr(runtime_service, "execute_tool_call", fake_execute_tool_call)
+
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                tool_traces=[
+                    ToolTrace(
+                        name="update_event_safe",
+                        tool_input={"event_id": "evt_1", "status": "confirmed"},
+                        tool_use_id="tool_2",
+                    )
+                ],
+                blocked_action=ToolAction(
+                    name="update_event_safe",
+                    action_class=ActionClass.WRITE,
+                    payload={"tool_input": {"event_id": "evt_1", "status": "confirmed"}},
+                ),
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Write tool trace test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Confirm the event")
+    )
+
+    assert response.run.status.value == "paused_approval"
+
+    state = await service.get_thread_state(thread.external_id)
+    approval = state.approvals[0]
+
+    decision = await service.submit_approval(
+        approval.external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.APPROVED),
+    )
+
+    assert decision.run.status.value == "completed"
+    assert len(executed) == 1
+
+    full_state = await service.get_thread_state(thread.external_id)
+    kinds = _trace_kinds(full_state.traces)
+    assert "approval_resolution" in kinds
+    assert "tool_start" in kinds, "Missing TOOL_START trace after approval"
+    assert "tool_completion" in kinds, "Missing TOOL_COMPLETION trace after approval"
+    assert "run_completed" in kinds
+
+    _assert_monotonic_sequences(full_state.traces)
+    _assert_valid_detail_json(full_state.traces)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Guardrail retry traces
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_guardrail_retry_emits_trace() -> None:
+    """SUCCESS: A guardrail retry produces a GUARDRAIL_RETRY trace."""
+    adapter = FakeToolAwareAdapter(
+        [
+            AgentTurnResult(
+                text_deltas=[
+                    "I apologize, but I'm unable to retrieve the most recent event stats right now."
+                ],
+                final_text=(
+                    "I apologize, but I'm unable to retrieve the most recent event stats right now. "
+                    "Access issues are blocking me."
+                ),
+            ),
+            AgentTurnResult(
+                text_deltas=["I found the latest event attendance."],
+                final_text="The latest event had 42 attendees.",
+                tool_traces=[
+                    ToolTrace(name="list_events", tool_input={"limit": 5}, tool_use_id="tool_1", result=[{"_id": "evt_1"}]),
+                    ToolTrace(
+                        name="get_event_attendance",
+                        tool_input={"event_id": "evt_1"},
+                        tool_use_id="tool_2",
+                        result={"event": {"_id": "evt_1"}, "attendees": [{"email": "a@example.com"}]},
+                    ),
+                ],
+            ),
+        ]
+    )
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=adapter,
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Retry trace test"))
+    response = await service.start_run(
+        RunCreateRequest(
+            thread_id=thread.external_id,
+            input_text="What were the latest event stats with actual attendance?",
+        )
+    )
+
+    assert response.run.status.value == "completed"
+
+    kinds = _trace_kinds(response.traces)
+    assert "guardrail_retry" in kinds, "Missing GUARDRAIL_RETRY trace"
+    assert "tool_selection" in kinds, "Missing TOOL_SELECTION trace after retry"
+
+    _assert_valid_detail_json(response.traces)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Trace stream events
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_trace_steps_appear_as_stream_events() -> None:
+    """SUCCESS: Each trace step is also emitted as a 'trace.step' stream event."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Stream event test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Hello world")
+    )
+
+    trace_events = [e for e in response.events if e.event == "trace.step"]
+    assert len(trace_events) >= 3, f"Expected at least 3 trace.step events, got {len(trace_events)}"
+
+    # Each trace.step event should have kind, summary, and sequence
+    for event in trace_events:
+        assert "kind" in event.data
+        assert "summary" in event.data
+        assert "sequence" in event.data
+
+
+@pytest.mark.asyncio
+async def test_trace_step_events_do_not_leak_provider_data() -> None:
+    """SUCCESS: trace.step stream events contain no raw provider payloads."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="No leak test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Test no leak")
+    )
+
+    for event in response.events:
+        if event.event == "trace.step":
+            serialized = json.dumps(event.data)
+            assert "provider_event" not in serialized
+            assert "anthropic" not in serialized.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Failure states
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_zero_traces_is_failure_state() -> None:
+    """FAILURE STATE: A completed run with zero traces indicates a broken trace pipeline.
+    This test verifies the pipeline is NOT broken by asserting traces > 0."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Zero trace check"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Simple request")
+    )
+
+    assert response.run.status.value == "completed"
+    assert len(response.traces) > 0, "FAILURE: Completed run has zero traces — trace pipeline is broken"
+
+
+@pytest.mark.asyncio
+async def test_trace_sequence_ordering_invariant() -> None:
+    """FAILURE STATE: Out-of-order traces indicate a regression in the emit pipeline."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Result"],
+                final_text="Done",
+                tool_traces=[
+                    ToolTrace(name="list_events", tool_input={"limit": 5}, tool_use_id="t1", result=[{"_id": "e1"}]),
+                    ToolTrace(name="get_event_attendance", tool_input={"event_id": "e1"}, tool_use_id="t2", result={"attendees": []}),
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Ordering test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Check attendance")
+    )
+
+    sequences = [t.sequence_number for t in response.traces]
+    assert sequences == sorted(sequences), f"FAILURE: Traces out of order: {sequences}"
+    assert len(sequences) == len(set(sequences)), f"FAILURE: Duplicate sequence numbers: {sequences}"
+
+
+@pytest.mark.asyncio
+async def test_invalid_detail_json_is_failure_state() -> None:
+    """FAILURE STATE: Traces with invalid detail_json indicate serialization bugs.
+    This test verifies all detail_json values are valid JSON."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Done"],
+                final_text="Complete",
+                tool_traces=[
+                    ToolTrace(
+                        name="get_attendance_dashboard",
+                        tool_input={"filter": "recent"},
+                        tool_use_id="t1",
+                        result={"total": 100},
+                    )
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="JSON validity test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Dashboard stats")
+    )
+
+    for trace in response.traces:
+        if trace.detail_json is not None:
+            try:
+                parsed = json.loads(trace.detail_json)
+                assert isinstance(parsed, dict), f"Expected dict, got {type(parsed)}"
+            except json.JSONDecodeError as exc:
+                pytest.fail(f"FAILURE: Invalid detail_json in trace {trace.external_id}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tests: TraceStepKind enum completeness
+# ---------------------------------------------------------------------------
+
+def test_trace_step_kind_enum_values() -> None:
+    """Verify all expected trace kinds exist in the enum."""
+    expected = {
+        "planning",
+        "tool_selection",
+        "tool_start",
+        "tool_completion",
+        "tool_failure",
+        "approval_pause",
+        "approval_resolution",
+        "artifact_generation",
+        "thinking",
+        "guardrail_retry",
+        "run_completed",
+        "run_error",
+    }
+    actual = {kind.value for kind in TraceStepKind}
+    assert expected == actual, f"Mismatch: missing={expected - actual}, extra={actual - expected}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Store-level trace operations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_store_append_and_list_traces() -> None:
+    """Verify InMemoryRuntimeStore trace operations work correctly."""
+    from runtime.normalize import make_trace_step
+
+    store = InMemoryRuntimeStore()
+
+    trace1 = make_trace_step(
+        external_id="trace_1",
+        thread_id="thread_1",
+        run_id="run_1",
+        kind=TraceStepKind.PLANNING,
+        sequence_number=1,
+        summary="Planning step",
+    )
+    trace2 = make_trace_step(
+        external_id="trace_2",
+        thread_id="thread_1",
+        run_id="run_1",
+        kind=TraceStepKind.THINKING,
+        sequence_number=2,
+        summary="Thinking step",
+    )
+    trace3 = make_trace_step(
+        external_id="trace_3",
+        thread_id="thread_1",
+        run_id="run_2",
+        kind=TraceStepKind.PLANNING,
+        sequence_number=1,
+        summary="Another run planning",
+    )
+
+    await store.append_trace(trace1)
+    await store.append_trace(trace2)
+    await store.append_trace(trace3)
+
+    # List by run
+    run1_traces = await store.list_traces_for_run("run_1")
+    assert len(run1_traces) == 2
+    assert run1_traces[0].external_id == "trace_1"
+    assert run1_traces[1].external_id == "trace_2"
+
+    # List by thread
+    thread_traces = await store.list_traces_for_thread("thread_1")
+    assert len(thread_traces) == 3
+
+    # Sequence counter
+    seq = await store.next_trace_sequence("run_new")
+    assert seq == 1
+    seq2 = await store.next_trace_sequence("run_new")
+    assert seq2 == 2

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
-import type { AgentMessage, AgentApproval, AgentThread } from "./types";
+import type { AgentMessage, AgentApproval, AgentThread, AgentTraceStep } from "./types";
 import { MessageBubble } from "./MessageBubble";
 import { ApprovalCard } from "./ApprovalCard";
 import { AgentInput } from "./AgentInput";
+import { TraceRail } from "./TraceRail";
 import {
   createThread,
   getThreadState,
@@ -33,6 +34,8 @@ export function ConversationTimeline({
 }: ConversationTimelineProps) {
   const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [approvals, setApprovals] = useState<AgentApproval[]>([]);
+  const [traces, setTraces] = useState<AgentTraceStep[]>([]);
+  const [traceCollapsed, setTraceCollapsed] = useState(true);
   const [streamingText, setStreamingText] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -44,6 +47,7 @@ export function ConversationTimeline({
     if (threadIdRef.current !== threadId) return;
     setMessages(state.messages);
     setApprovals(state.approvals);
+    setTraces(state.traces ?? []);
     setLoaded(true);
   }
 
@@ -52,6 +56,7 @@ export function ConversationTimeline({
       threadIdRef.current = null;
       setMessages([]);
       setApprovals([]);
+      setTraces([]);
       setLoaded(true);
       return;
     }
@@ -61,6 +66,7 @@ export function ConversationTimeline({
     setLoaded(false);
     setMessages([]);
     setApprovals([]);
+    setTraces([]);
     setStreamingText(null);
 
     void refreshThreadState(thread.id);
@@ -81,10 +87,12 @@ export function ConversationTimeline({
       setLoaded(true);
       setMessages([]);
       setApprovals([]);
+      setTraces([]);
     }
 
     setIsRunning(true);
     setStreamingText("");
+    setTraceCollapsed(true);
 
     const optimisticUser: AgentMessage = {
       id: `opt-user-${Date.now()}`,
@@ -96,22 +104,10 @@ export function ConversationTimeline({
     setMessages((prev) => [...prev, optimisticUser]);
 
     try {
-      await startRun(
-        thread.id,
-        text,
-        (chunk) => setStreamingText(chunk),
-        (done) => {
-          setStreamingText(null);
-          // Replace optimistic user message with real messages from adapter
-          setMessages((prev) => {
-            const withoutOptimistic = prev.filter(
-              (m) => m.id !== optimisticUser.id,
-            );
-            return [...withoutOptimistic, optimisticUser, done];
-          });
-          onArtifactsChange?.();
-        },
-      );
+      await startRun(workingThread.id, text, (chunk) => setStreamingText(chunk));
+      // After run completes, refresh full state to get traces, messages, approvals
+      await refreshThreadState(workingThread.id);
+      onArtifactsChange?.(workingThread.id);
     } finally {
       setIsRunning(false);
       setStreamingText(null);
@@ -179,6 +175,16 @@ export function ConversationTimeline({
             ))}
 
             <div ref={bottomRef} />
+          </div>
+        )}
+
+        {traces.length > 0 && (
+          <div className="border-t border-[#F0F0F0] py-3">
+            <TraceRail
+              traces={traces}
+              collapsed={traceCollapsed}
+              onToggle={() => setTraceCollapsed((prev) => !prev)}
+            />
           </div>
         )}
       </div>

--- a/fe+convex/components/agent/TraceRail.tsx
+++ b/fe+convex/components/agent/TraceRail.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { AgentTraceStep, TraceStepKind } from "./types";
+
+interface TraceRailProps {
+  traces: AgentTraceStep[];
+  collapsed?: boolean;
+  onToggle?: () => void;
+}
+
+const STEP_ICONS: Record<TraceStepKind, string> = {
+  planning: "\u{1F4CB}",
+  tool_selection: "\u{1F50D}",
+  tool_start: "\u{2699}\u{FE0F}",
+  tool_completion: "\u{2705}",
+  tool_failure: "\u{274C}",
+  approval_pause: "\u{23F8}\u{FE0F}",
+  approval_resolution: "\u{2714}\u{FE0F}",
+  artifact_generation: "\u{1F4E6}",
+  thinking: "\u{1F4AD}",
+  guardrail_retry: "\u{1F504}",
+  run_completed: "\u{1F3C1}",
+  run_error: "\u{26A0}\u{FE0F}",
+};
+
+const STEP_COLORS: Record<TraceStepKind, string> = {
+  planning: "text-blue-600",
+  tool_selection: "text-indigo-600",
+  tool_start: "text-gray-600",
+  tool_completion: "text-green-600",
+  tool_failure: "text-red-600",
+  approval_pause: "text-yellow-600",
+  approval_resolution: "text-green-700",
+  artifact_generation: "text-purple-600",
+  thinking: "text-gray-500",
+  guardrail_retry: "text-orange-600",
+  run_completed: "text-green-700",
+  run_error: "text-red-700",
+};
+
+function formatKind(kind: TraceStepKind): string {
+  return kind
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function TraceRail({ traces, collapsed = true, onToggle }: TraceRailProps) {
+  if (traces.length === 0) return null;
+
+  return (
+    <div className="mx-auto max-w-[700px] px-5">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-1.5 text-[11px] font-medium text-[#999999] transition-colors hover:text-[#666666]"
+        type="button"
+      >
+        <span
+          className="inline-block transition-transform"
+          style={{ transform: collapsed ? "rotate(0deg)" : "rotate(90deg)" }}
+        >
+          &#9654;
+        </span>
+        Reasoning trace ({traces.length} step{traces.length !== 1 ? "s" : ""})
+      </button>
+
+      {!collapsed && (
+        <div className="mt-2 ml-2 border-l-2 border-[#E5E5E5] pl-3">
+          {traces.map((step) => (
+            <div key={step.id} className="relative mb-2 last:mb-0">
+              <div
+                className="absolute -left-[17px] top-0.5 h-2.5 w-2.5 rounded-full border-2 border-white"
+                style={{
+                  backgroundColor:
+                    step.status === "waiting"
+                      ? "#F59E0B"
+                      : step.kind === "run_error" || step.kind === "tool_failure"
+                        ? "#EF4444"
+                        : step.kind === "run_completed"
+                          ? "#10B981"
+                          : "#9CA3AF",
+                }}
+              />
+              <div className="flex items-start gap-1.5">
+                <span className="text-[11px] leading-[16px]">
+                  {STEP_ICONS[step.kind] ?? "\u{25CF}"}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span
+                    className={`text-[11px] font-medium leading-[16px] ${STEP_COLORS[step.kind] ?? "text-gray-600"}`}
+                  >
+                    {formatKind(step.kind)}
+                  </span>
+                  <p className="text-[11px] leading-[15px] text-[#777777]">
+                    {step.summary}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fe+convex/components/agent/adapters/runtime.ts
+++ b/fe+convex/components/agent/adapters/runtime.ts
@@ -5,8 +5,10 @@ import type {
   AgentRun,
   AgentThread,
   AgentThreadState,
+  AgentTraceStep,
   ContentBlock,
   ReportBlock,
+  TraceStepKind,
 } from "../types";
 
 type BackendThread = {
@@ -66,12 +68,24 @@ type BackendApproval = {
   requested_at: number;
 };
 
+type BackendTrace = {
+  external_id: string;
+  run_external_id: string;
+  kind: string;
+  sequence_number: number;
+  summary: string;
+  detail_json?: string | null;
+  status: string;
+  created_at: number;
+};
+
 type BackendThreadState = {
   thread: BackendThread;
   runs: BackendRun[];
   messages: BackendMessage[];
   artifacts: BackendArtifact[];
   approvals: BackendApproval[];
+  traces?: BackendTrace[];
 };
 
 type RunStreamEvent = {
@@ -82,6 +96,7 @@ type RunStreamEvent = {
 type RunWithEventsResponse = {
   run: BackendRun & { error_message?: string | null };
   events: RunStreamEvent[];
+  traces?: BackendTrace[];
 };
 
 const API_BASE = "/api/agent";
@@ -201,6 +216,19 @@ function mapApproval(approval: BackendApproval): AgentApproval {
   };
 }
 
+function mapTrace(trace: BackendTrace): AgentTraceStep {
+  return {
+    id: trace.external_id,
+    runId: trace.run_external_id,
+    kind: trace.kind as TraceStepKind,
+    sequenceNumber: trace.sequence_number,
+    summary: trace.summary,
+    detailJson: trace.detail_json,
+    status: trace.status,
+    createdAt: trace.created_at,
+  };
+}
+
 function mapRun(run: BackendRun): AgentRun {
   return {
     id: run.external_id,
@@ -249,6 +277,7 @@ export async function getThreadState(threadId: string): Promise<AgentThreadState
     messages: state.messages.map(mapMessage),
     artifacts: state.artifacts.map(mapArtifact),
     approvals: state.approvals.map(mapApproval),
+    traces: (state.traces ?? []).map(mapTrace),
   };
 }
 

--- a/fe+convex/components/agent/types.ts
+++ b/fe+convex/components/agent/types.ts
@@ -121,6 +121,31 @@ export interface ContextLink {
   label: string;
 }
 
+export type TraceStepKind =
+  | "planning"
+  | "tool_selection"
+  | "tool_start"
+  | "tool_completion"
+  | "tool_failure"
+  | "approval_pause"
+  | "approval_resolution"
+  | "artifact_generation"
+  | "thinking"
+  | "guardrail_retry"
+  | "run_completed"
+  | "run_error";
+
+export interface AgentTraceStep {
+  id: string;
+  runId: string;
+  kind: TraceStepKind;
+  sequenceNumber: number;
+  summary: string;
+  detailJson?: string | null;
+  status: string;
+  createdAt: number;
+}
+
 export interface AgentRun {
   id: string;
   threadId: string;
@@ -136,4 +161,5 @@ export interface AgentThreadState {
   messages: AgentMessage[];
   artifacts: AgentArtifact[];
   approvals: AgentApproval[];
+  traces: AgentTraceStep[];
 }

--- a/fe+convex/convex/agentState.test.ts
+++ b/fe+convex/convex/agentState.test.ts
@@ -20,6 +20,7 @@ type TableName =
   | "agent_messages"
   | "agent_artifacts"
   | "agent_approvals"
+  | "agent_traces"
   | "agent_context_links";
 
 type TableRow = { _id: string } & Record<string, unknown>;
@@ -70,6 +71,7 @@ class FakeDb {
     agent_messages: 0,
     agent_artifacts: 0,
     agent_approvals: 0,
+    agent_traces: 0,
     agent_context_links: 0,
   };
 
@@ -79,6 +81,7 @@ class FakeDb {
     agent_messages: [],
     agent_artifacts: [],
     agent_approvals: [],
+    agent_traces: [],
     agent_context_links: [],
   };
 

--- a/fe+convex/convex/agentState.trace.test.ts
+++ b/fe+convex/convex/agentState.trace.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Tests for the agent_traces Convex persistence layer (Issue #20).
+ *
+ * Success States:
+ *   - appendTrace inserts a new trace row with correct fields.
+ *   - appendTrace upserts (patches) when called with the same external_id.
+ *   - getThreadState returns traces sorted by sequence_number ascending.
+ *   - getRunState returns only traces belonging to that run.
+ *   - Trace rows have no raw provider payloads.
+ *
+ * Failure States:
+ *   - Missing trace rows after appendTrace indicates a persistence bug.
+ *   - Traces returned out of sequence_number order indicates a sorting bug.
+ *   - Duplicate external_ids after upsert indicates idempotency is broken.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  appendMessage,
+  appendTrace,
+  getRunState,
+  getThreadState,
+  listPendingApprovals,
+  listThreads,
+  resolveApproval,
+  upsertApproval,
+  upsertArtifact,
+  upsertContextLink,
+  upsertRun,
+  upsertThread,
+} from "./agentState";
+
+type TableName =
+  | "agent_threads"
+  | "agent_runs"
+  | "agent_messages"
+  | "agent_artifacts"
+  | "agent_approvals"
+  | "agent_traces"
+  | "agent_context_links";
+
+type TableRow = { _id: string } & Record<string, unknown>;
+type Tables = Record<TableName, TableRow[]>;
+
+class FakeIndexRangeBuilder {
+  readonly filters: Array<[string, unknown]> = [];
+
+  eq(field: string, value: unknown) {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+class FakeQuery {
+  constructor(
+    private readonly rows: TableRow[],
+    private readonly filters: Array<[string, unknown]> = []
+  ) {}
+
+  withIndex(_indexName: string, build: (builder: FakeIndexRangeBuilder) => unknown) {
+    const builder = new FakeIndexRangeBuilder();
+    build(builder);
+    return new FakeQuery(this.rows, builder.filters);
+  }
+
+  async collect() {
+    return this.rows.filter((row) =>
+      this.filters.every(([field, value]) => row[field] === value)
+    );
+  }
+
+  async first() {
+    const matches = await this.collect();
+    return matches[0] ?? null;
+  }
+
+  async unique() {
+    const matches = await this.collect();
+    return matches[0] ?? null;
+  }
+}
+
+class FakeDb {
+  private readonly counters: Record<TableName, number> = {
+    agent_threads: 0,
+    agent_runs: 0,
+    agent_messages: 0,
+    agent_artifacts: 0,
+    agent_approvals: 0,
+    agent_traces: 0,
+    agent_context_links: 0,
+  };
+
+  readonly tables: Tables = {
+    agent_threads: [],
+    agent_runs: [],
+    agent_messages: [],
+    agent_artifacts: [],
+    agent_approvals: [],
+    agent_traces: [],
+    agent_context_links: [],
+  };
+
+  query(table: TableName) {
+    return new FakeQuery(this.tables[table]);
+  }
+
+  async get(id: string) {
+    const table = id.split(":")[0] as TableName;
+    return this.tables[table].find((row) => row._id === id) ?? null;
+  }
+
+  async insert(table: TableName, value: Record<string, unknown>) {
+    const id = `${table}:${++this.counters[table]}`;
+    this.tables[table].push({ _id: id, ...value });
+    return id;
+  }
+
+  async patch(id: string, value: Record<string, unknown>) {
+    const table = id.split(":")[0] as TableName;
+    const index = this.tables[table].findIndex((row) => row._id === id);
+    if (index === -1) {
+      throw new Error(`Missing row: ${id}`);
+    }
+
+    this.tables[table][index] = {
+      ...this.tables[table][index],
+      ...value,
+    };
+  }
+
+  rows(table: TableName) {
+    return [...this.tables[table]];
+  }
+}
+
+function installConvexHandlerAliases() {
+  for (const fn of [
+    appendMessage,
+    appendTrace,
+    getRunState,
+    getThreadState,
+    listPendingApprovals,
+    listThreads,
+    resolveApproval,
+    upsertApproval,
+    upsertArtifact,
+    upsertContextLink,
+    upsertRun,
+    upsertThread,
+  ]) {
+    const wrapped = fn as typeof fn & { handler?: unknown; _handler?: unknown };
+    if (!wrapped.handler) {
+      wrapped.handler = wrapped._handler;
+    }
+  }
+}
+
+function getHandler<TArgs, TResult>(fn: unknown) {
+  const wrapped = fn as {
+    handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+    _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+  };
+  const handler = wrapped.handler ?? wrapped._handler;
+  if (!handler) {
+    throw new Error("Convex handler is unavailable in test harness");
+  }
+  return handler;
+}
+
+function createHarness() {
+  installConvexHandlerAliases();
+  const db = new FakeDb();
+  const ctx = { db };
+  return { db, ctx };
+}
+
+describe("agent trace persistence", () => {
+  test("appendTrace inserts a new trace row", async () => {
+    const { ctx, db } = createHarness();
+
+    // Create prerequisite thread and run
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_trace_1",
+      channel: "web",
+      status: "active",
+      updated_at: 100,
+    });
+
+    const runId = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_trace_1",
+      status: "running",
+      trigger_source: "web",
+      updated_at: 110,
+    });
+
+    // Insert trace
+    const traceId = await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        detail_json?: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_planning_1",
+      kind: "planning",
+      sequence_number: 1,
+      summary: "Analyzing request and planning execution strategy.",
+      detail_json: undefined,
+      status: "completed",
+      created_at: 115,
+      updated_at: 115,
+    });
+
+    expect(traceId).toBeTruthy();
+    expect(db.rows("agent_traces")).toHaveLength(1);
+    expect(db.rows("agent_traces")[0]).toMatchObject({
+      external_id: "trace_planning_1",
+      kind: "planning",
+      sequence_number: 1,
+      summary: "Analyzing request and planning execution strategy.",
+      status: "completed",
+    });
+  });
+
+  test("appendTrace upserts on same external_id", async () => {
+    const { ctx, db } = createHarness();
+
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_upsert",
+      channel: "web",
+      status: "active",
+      updated_at: 100,
+    });
+
+    const runId = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_upsert",
+      status: "running",
+      trigger_source: "web",
+      updated_at: 110,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_upsert_1",
+      kind: "approval_pause",
+      sequence_number: 1,
+      summary: "Waiting for approval",
+      status: "waiting",
+      updated_at: 120,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_upsert_1",
+      kind: "approval_pause",
+      sequence_number: 1,
+      summary: "Waiting for approval (updated)",
+      status: "completed",
+      updated_at: 130,
+    });
+
+    expect(db.rows("agent_traces")).toHaveLength(1);
+    expect(db.rows("agent_traces")[0]).toMatchObject({
+      summary: "Waiting for approval (updated)",
+      status: "completed",
+    });
+  });
+
+  test("getThreadState includes traces sorted by sequence_number", async () => {
+    const { ctx } = createHarness();
+
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_state_traces",
+      channel: "web",
+      status: "active",
+      updated_at: 100,
+    });
+
+    const runId = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_state_traces",
+      status: "completed",
+      trigger_source: "web",
+      updated_at: 200,
+    });
+
+    // Insert traces out of order
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_3",
+      kind: "run_completed",
+      sequence_number: 3,
+      summary: "Run completed",
+      status: "completed",
+      created_at: 160,
+      updated_at: 160,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_1",
+      kind: "planning",
+      sequence_number: 1,
+      summary: "Planning",
+      status: "completed",
+      created_at: 120,
+      updated_at: 120,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        detail_json?: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_2",
+      kind: "tool_completion",
+      sequence_number: 2,
+      summary: "Tool completed",
+      detail_json: '{"tool":"list_events"}',
+      status: "completed",
+      created_at: 140,
+      updated_at: 140,
+    });
+
+    const threadState = await getHandler<
+      { external_id?: string; thread_id?: string },
+      {
+        thread: Record<string, unknown>;
+        traces: Array<Record<string, unknown>>;
+      }
+    >(getThreadState)(ctx as never, { external_id: "thread_state_traces" });
+
+    expect(threadState.traces).toHaveLength(3);
+    expect(threadState.traces.map((t) => t.sequence_number)).toEqual([1, 2, 3]);
+    expect(threadState.traces.map((t) => t.kind)).toEqual([
+      "planning",
+      "tool_completion",
+      "run_completed",
+    ]);
+  });
+
+  test("getRunState includes only traces for that run", async () => {
+    const { ctx } = createHarness();
+
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_run_filter",
+      channel: "web",
+      status: "active",
+      updated_at: 100,
+    });
+
+    const run1Id = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_filter_1",
+      status: "completed",
+      trigger_source: "web",
+      updated_at: 200,
+    });
+
+    const run2Id = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_filter_2",
+      status: "completed",
+      trigger_source: "web",
+      updated_at: 300,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: run1Id,
+      external_id: "trace_r1",
+      kind: "planning",
+      sequence_number: 1,
+      summary: "Run 1 planning",
+      status: "completed",
+      updated_at: 150,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: run2Id,
+      external_id: "trace_r2",
+      kind: "thinking",
+      sequence_number: 1,
+      summary: "Run 2 thinking",
+      status: "completed",
+      updated_at: 250,
+    });
+
+    const runState = await getHandler<
+      { external_id?: string; run_id?: string },
+      {
+        run: Record<string, unknown>;
+        traces: Array<Record<string, unknown>>;
+      }
+    >(getRunState)(ctx as never, { external_id: "run_filter_1" });
+
+    expect(runState.traces).toHaveLength(1);
+    expect(runState.traces[0].external_id).toBe("trace_r1");
+  });
+
+  test("trace rows contain no raw provider payloads", async () => {
+    const { ctx, db } = createHarness();
+
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_no_leak",
+      channel: "web",
+      status: "active",
+      updated_at: 100,
+    });
+
+    const runId = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_no_leak",
+      status: "completed",
+      trigger_source: "web",
+      updated_at: 200,
+    });
+
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        detail_json?: string;
+        status: string;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_no_leak",
+      kind: "tool_completion",
+      sequence_number: 1,
+      summary: "Tool list_events completed.",
+      detail_json: '{"tool":"list_events","result":[]}',
+      status: "completed",
+      updated_at: 150,
+    });
+
+    const rows = db.rows("agent_traces");
+    for (const row of rows) {
+      const serialized = JSON.stringify(row);
+      expect(serialized).not.toContain("provider_event");
+      expect(serialized.toLowerCase()).not.toContain("anthropic");
+    }
+  });
+});

--- a/fe+convex/convex/agentState.ts
+++ b/fe+convex/convex/agentState.ts
@@ -71,6 +71,13 @@ async function getApprovalByExternalId(ctx: AgentDbContext, externalId: string) 
     .unique();
 }
 
+async function getTraceByExternalId(ctx: AgentDbContext, externalId: string) {
+  return await ctx.db
+    .query("agent_traces")
+    .withIndex("by_external_id", (q) => q.eq("external_id", externalId))
+    .unique();
+}
+
 async function getContextLinkByKey(ctx: AgentDbContext, linkKey: string) {
   return await ctx.db
     .query("agent_context_links")
@@ -172,7 +179,7 @@ export const getThreadState = query({
   handler: async (ctx, args) => {
     const thread = await requireThread(ctx, args);
 
-    const [runs, messages, artifacts, approvals, context_links] = await Promise.all([
+    const [runs, messages, artifacts, approvals, traces, context_links] = await Promise.all([
       ctx.db
         .query("agent_runs")
         .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
@@ -190,6 +197,10 @@ export const getThreadState = query({
         .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
         .collect(),
       ctx.db
+        .query("agent_traces")
+        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+        .collect(),
+      ctx.db
         .query("agent_context_links")
         .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
         .collect(),
@@ -201,6 +212,7 @@ export const getThreadState = query({
       messages: sortBySequenceAsc(messages),
       artifacts: sortByOrderAsc(artifacts),
       approvals: sortByRequestedDesc(approvals),
+      traces: sortBySequenceAsc(traces),
       context_links: sortByCreatedAsc(context_links),
     };
   },
@@ -214,7 +226,7 @@ export const getRunState = query({
   handler: async (ctx, args) => {
     const run = await requireRun(ctx, args);
 
-    const [messages, artifacts, approvals, context_links] = await Promise.all([
+    const [messages, artifacts, approvals, traces, context_links] = await Promise.all([
       ctx.db
         .query("agent_messages")
         .withIndex("by_run_id", (q) => q.eq("run_id", run._id))
@@ -228,6 +240,10 @@ export const getRunState = query({
         .withIndex("by_run_id", (q) => q.eq("run_id", run._id))
         .collect(),
       ctx.db
+        .query("agent_traces")
+        .withIndex("by_run_id", (q) => q.eq("run_id", run._id))
+        .collect(),
+      ctx.db
         .query("agent_context_links")
         .withIndex("by_run_id", (q) => q.eq("run_id", run._id))
         .collect(),
@@ -238,6 +254,7 @@ export const getRunState = query({
       messages: sortBySequenceAsc(messages),
       artifacts: sortByOrderAsc(artifacts),
       approvals: sortByRequestedDesc(approvals),
+      traces: sortBySequenceAsc(traces),
       context_links: sortByCreatedAsc(context_links),
     };
   },
@@ -597,6 +614,57 @@ export const resolveApproval = mutation({
     );
 
     return approval._id;
+  },
+});
+
+export const appendTrace = mutation({
+  args: {
+    thread_id: v.id("agent_threads"),
+    run_id: v.id("agent_runs"),
+    external_id: v.string(),
+    kind: v.string(),
+    sequence_number: v.number(),
+    summary: v.string(),
+    detail_json: v.optional(v.string()),
+    status: v.string(),
+    created_at: v.optional(v.number()),
+    updated_at: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = args.updated_at ?? Date.now();
+    const createdAt = args.created_at ?? now;
+    const existing = await getTraceByExternalId(ctx, args.external_id);
+
+    if (existing) {
+      await ctx.db.patch(
+        existing._id,
+        definedPatch({
+          thread_id: args.thread_id,
+          run_id: args.run_id,
+          kind: args.kind,
+          sequence_number: args.sequence_number,
+          summary: args.summary,
+          detail_json: args.detail_json,
+          status: args.status,
+          created_at: args.created_at,
+          updated_at: now,
+        })
+      );
+      return existing._id;
+    }
+
+    return await ctx.db.insert("agent_traces", {
+      thread_id: args.thread_id,
+      run_id: args.run_id,
+      external_id: args.external_id,
+      kind: args.kind,
+      sequence_number: args.sequence_number,
+      summary: args.summary,
+      detail_json: args.detail_json,
+      status: args.status,
+      created_at: createdAt,
+      updated_at: now,
+    });
   },
 });
 

--- a/fe+convex/convex/schema.ts
+++ b/fe+convex/convex/schema.ts
@@ -155,6 +155,23 @@ export default defineSchema({
     .index("by_status", ["status"])
     .index("by_thread_status", ["thread_id", "status"]),
 
+  agent_traces: defineTable({
+    thread_id: v.id("agent_threads"),
+    run_id: v.id("agent_runs"),
+    external_id: v.string(),
+    kind: v.string(),
+    sequence_number: v.number(),
+    summary: v.string(),
+    detail_json: v.optional(v.string()),
+    status: v.string(),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_external_id", ["external_id"])
+    .index("by_thread_id", ["thread_id"])
+    .index("by_run_id", ["run_id"])
+    .index("by_run_sequence", ["run_id", "sequence_number"]),
+
   agent_context_links: defineTable({
     thread_id: v.id("agent_threads"),
     run_id: v.optional(v.id("agent_runs")),


### PR DESCRIPTION
## Summary

Closes #20

Full-stack implementation of **persisted, structured reasoning traces** that survive page refresh and provide visibility into every step of the agent's decision-making process.

## Changes

### Backend (Python agent runtime)

| File | Change |
|------|--------|
| `contracts.py` | Added `TraceStepKind` enum (12 kinds) and `TraceStepRecord` Pydantic model |
| `store.py` | Added trace storage: `append_trace()`, `list_traces_for_run()`, `list_traces_for_thread()`, `next_trace_sequence()` |
| `normalize.py` | Added `make_trace_step()` factory helper |
| `service.py` | Emits trace steps at every lifecycle point: planning, thinking, tool_selection, tool_start, tool_completion, tool_failure, approval_pause, approval_resolution, artifact_generation, guardrail_retry, run_completed, run_error |
| `convex_sync.py` | Added `append_trace()` for Convex persistence |

### Convex Persistence Layer

| File | Change |
|------|--------|
| `schema.ts` | Added `agent_traces` table with `by_thread_id`, `by_run_id`, `by_external_id` indexes |
| `agentState.ts` | Added `appendTrace` mutation (upsert-on-external_id), included traces in `getThreadState` and `getRunState` queries |

### Frontend

| File | Change |
|------|--------|
| `types.ts` | Added `AgentTraceStep` interface and `TraceStepKind` union type |
| `adapters/runtime.ts` | Added `BackendTrace` type and `mapTrace()` function |
| `TraceRail.tsx` | New collapsible trace timeline component with step icons and status colors |
| `ConversationTimeline.tsx` | Integrated `TraceRail` below the message list |

## Testing

**21 new tests** (16 Python + 5 TypeScript), all passing alongside the 9 existing runtime tests:

### Python (`test_runtime_traces.py`)
- Simple text run emits planning + completed traces
- Traces appear in thread state
- Unique external IDs
- Tool-aware runs emit tool_selection + tool_completion
- Tool failures emit tool_failure trace
- Approval pause emits trace with status=waiting
- Approval resolution emits trace
- Approved write tool emits tool_start + tool_completion
- Guardrail retry emits trace
- Trace steps appear as stream events
- No provider data leaks in trace events
- Zero-traces failure state detection
- Sequence ordering invariant
- Invalid detail_json detection
- TraceStepKind enum completeness
- Store-level append/list operations

### TypeScript (`agentState.trace.test.ts`)
- appendTrace inserts new row
- appendTrace upserts on same external_id
- getThreadState returns traces sorted by sequence_number
- getRunState filters traces by run
- No raw provider payloads in trace rows

## Success / Failure States

**Success:**
- Every completed run has >= 3 traces (planning, artifact_generation, run_completed)
- Tool runs include tool_selection + tool_completion/tool_failure per tool
- Approval-paused runs include approval_pause with status=waiting
- Traces are monotonically ordered by sequence_number per run
- All detail_json values are valid JSON dicts
- No traces contain raw provider payloads

**Failure:**
- Completed run with zero traces = broken trace pipeline
- Out-of-order sequence numbers = emit pipeline regression
- Invalid detail_json = serialization bug
- Provider payload leak = normalization bypass
