### PR TITLE
feat: Streaming + persistence for agent runtime

### DIFF
--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -372,7 +372,7 @@ class AgentRuntimeService:
             raise HTTPException(status_code=500, detail="Run state missing after approval execution")
         return ApprovalDecisionResponse(approval=approval, run=resolved_run)
 
-    async def _pause_for_approval(self, *, run: RunRecord, action: ToolAction) -> RunRecord:
+    async def _pause_for_approval(self, *, run: RunRecord, action: ToolAction, streaming_message: MessageRecord | None = None) -> RunRecord:
         decision = self._policy.evaluate(action)
         now = _now_ms()
         approval = ApprovalRecord(
@@ -402,13 +402,14 @@ class AgentRuntimeService:
         await self._store.upsert_run(run)
         await self._sync.upsert_run(run)
 
-        await self._append_message(
-            thread_id=run.thread_external_id,
-            run_id=run.external_id,
-            role="assistant",
-            status="final",
-            blocks=[text_block("This action requires approval before execution.")],
-        )
+        if not streaming_message:
+            await self._append_message(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                role="assistant",
+                status="final",
+                blocks=[text_block("This action requires approval before execution.")],
+            )
         await self._store.append_stream_event(
             run_id=run.external_id,
             event="approval.requested",
@@ -599,7 +600,7 @@ class AgentRuntimeService:
             await self._patch_streaming_assistant_message(
                 assistant_msg, final_text, status="final"
             )
-            await self._pause_for_approval(run=run, action=result.blocked_action)
+            await self._pause_for_approval(run=run, action=result.blocked_action, streaming_message=assistant_msg)
             return
 
         final_text = result.final_text or latest_text or "I finished the run but produced no text output."

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -533,9 +533,15 @@ class AgentRuntimeService:
             was_retried=retried,
         )
 
+        # Create a streaming assistant placeholder before first delta
+        assistant_msg = await self._begin_streaming_assistant_message(run=run)
+
         latest_text = ""
         for partial_text in result.text_deltas:
             latest_text = partial_text
+            assistant_msg = await self._patch_streaming_assistant_message(
+                assistant_msg, latest_text
+            )
             await self._store.append_stream_event(
                 run_id=run.external_id,
                 event="assistant.delta",
@@ -588,13 +594,23 @@ class AgentRuntimeService:
                 )
 
         if result.blocked_action:
+            # Finalize the streaming message before pausing
+            final_text = latest_text or "This action requires approval before execution."
+            await self._patch_streaming_assistant_message(
+                assistant_msg, final_text, status="final"
+            )
             await self._pause_for_approval(run=run, action=result.blocked_action)
             return
 
         final_text = result.final_text or latest_text or "I finished the run but produced no text output."
-        await self._finalize_successful_run(run=run, text=final_text)
+        await self._finalize_successful_run(
+            run=run, text=final_text, streaming_message=assistant_msg
+        )
 
     async def _execute_text_run(self, *, run: RunRecord, user_input: str, max_tokens: int) -> None:
+        # Create a streaming assistant placeholder before first delta
+        assistant_msg = await self._begin_streaming_assistant_message(run=run)
+
         latest_text = ""
         try:
             async for partial_text in self._adapter.stream_text(
@@ -602,6 +618,9 @@ class AgentRuntimeService:
                 max_tokens=max_tokens,
             ):
                 latest_text = partial_text
+                assistant_msg = await self._patch_streaming_assistant_message(
+                    assistant_msg, latest_text
+                )
                 await self._store.append_stream_event(
                     run_id=run.external_id,
                     event="assistant.delta",
@@ -609,6 +628,12 @@ class AgentRuntimeService:
                     data={"text": partial_text},
                 )
         except Exception as exc:
+            # Finalize the streaming message as error before marking run error
+            await self._patch_streaming_assistant_message(
+                assistant_msg,
+                latest_text or f"Error: {exc}",
+                status="final",
+            )
             await self._emit_trace(
                 thread_id=run.thread_external_id,
                 run_id=run.external_id,
@@ -618,16 +643,74 @@ class AgentRuntimeService:
             await self._mark_run_error(run=run, message=str(exc))
             return
 
-        await self._finalize_successful_run(run=run, text=latest_text)
-
-    async def _finalize_successful_run(self, *, run: RunRecord, text: str) -> None:
-        assistant_message = await self._append_message(
-            thread_id=run.thread_external_id,
-            run_id=run.external_id,
-            role="assistant",
-            status="final",
-            blocks=[text_block(text)],
+        await self._finalize_successful_run(
+            run=run, text=latest_text, streaming_message=assistant_msg
         )
+
+    async def _begin_streaming_assistant_message(
+        self, *, run: RunRecord
+    ) -> MessageRecord:
+        """Create an empty assistant message placeholder before the first delta."""
+        now = _now_ms()
+        sequence = await self._store.next_sequence(run.thread_external_id)
+        message = MessageRecord(
+            external_id=f"msg_{uuid4().hex}",
+            thread_external_id=run.thread_external_id,
+            run_external_id=run.external_id,
+            role="assistant",
+            status="streaming",
+            sequence_number=sequence,
+            plain_text="",
+            content_blocks=[text_block("")],
+            created_at=now,
+            updated_at=now,
+        )
+        await self._store.append_message(message)
+        await self._sync.append_message(message)
+        return message
+
+    async def _patch_streaming_assistant_message(
+        self,
+        message: MessageRecord,
+        text: str,
+        *,
+        status: str = "streaming",
+    ) -> MessageRecord:
+        """Patch the existing streaming assistant message in place by external_id."""
+        updated = message.model_copy(
+            update={
+                "status": status,
+                "plain_text": text,
+                "content_blocks": [text_block(text)],
+                "updated_at": _now_ms(),
+            }
+        )
+        await self._store.append_message(updated)
+        await self._sync.append_message(updated)
+        return updated
+
+    async def _finalize_successful_run(
+        self,
+        *,
+        run: RunRecord,
+        text: str,
+        streaming_message: MessageRecord | None = None,
+    ) -> None:
+        if streaming_message is not None:
+            # Patch the existing streaming message to final status instead of
+            # creating a new assistant message row.
+            assistant_message = await self._patch_streaming_assistant_message(
+                streaming_message, text, status="final"
+            )
+        else:
+            # Legacy path: create a new final assistant message (e.g. rejection).
+            assistant_message = await self._append_message(
+                thread_id=run.thread_external_id,
+                run_id=run.external_id,
+                role="assistant",
+                status="final",
+                blocks=[text_block(text)],
+            )
 
         artifact = make_report_artifact(
             external_id=f"artifact_{uuid4().hex}",

--- a/agent/tests/test_runtime_service.py
+++ b/agent/tests/test_runtime_service.py
@@ -354,3 +354,158 @@ async def test_latest_event_request_with_no_events_returns_no_data_message() -> 
     assert response.run.status.value == "completed"
     state = await service.get_thread_state(thread.external_id)
     assert "couldn't find any events" in (state.messages[-1].plain_text or "").lower()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# New streaming-persistence tests for issue #33
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_streaming_placeholder_created_before_first_delta() -> None:
+    """Assistant placeholder is created before the first delta and patched in
+    place during streaming (text run path)."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Streaming test"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Hello world")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+
+    # There should be exactly one assistant message (the placeholder that was
+    # patched to final), not two separate rows.
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+    assert assistant_msgs[0].plain_text  # non-empty final text
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalization_patches_same_message_not_new_row() -> None:
+    """Finalization updates the same assistant message to status='final'
+    instead of adding a second assistant message."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Finalize test"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Summarize something")
+    )
+
+    # Count all messages in the store keyed by external_id.
+    all_msgs = list(store.messages.values())
+    assistant_msgs = [m for m in all_msgs if m.role == "assistant" and m.thread_external_id == thread.external_id]
+
+    # Only one assistant message row should exist.
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+
+    # The sequence_number should not have been advanced during streaming.
+    seq = assistant_msgs[0].sequence_number
+    user_msgs = [m for m in all_msgs if m.role == "user" and m.thread_external_id == thread.external_id]
+    assert len(user_msgs) == 1
+    assert user_msgs[0].sequence_number < seq
+
+
+@pytest.mark.asyncio
+async def test_tool_aware_streaming_placeholder_patched_in_place() -> None:
+    """For tool-aware runs, the assistant placeholder is created before the
+    first delta and patched in place during streaming."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Partial text", "Full answer ready"],
+                final_text="Full answer ready",
+                tool_traces=[
+                    ToolTrace(
+                        name="get_attendance_dashboard",
+                        tool_input={},
+                        tool_use_id="tool_1",
+                        result={"totals": {"events_tracked": 1}},
+                    )
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Tool streaming"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Show attendance")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+
+    # Exactly one assistant message, patched to final.
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+    assert assistant_msgs[0].plain_text == "Full answer ready"
+
+
+@pytest.mark.asyncio
+async def test_completed_run_shows_final_assistant_bubble() -> None:
+    """A completed run still shows the final assistant bubble (visible after
+    the run completes and after a simulated page refresh via get_thread_state)."""
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Bubble test"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Tell me something")
+    )
+
+    assert response.run.status.value == "completed"
+
+    # Simulate a "page refresh" by fetching thread state again.
+    state = await service.get_thread_state(thread.external_id)
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+    assert assistant_msgs[0].plain_text  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_sequence_number_not_advanced_during_streaming() -> None:
+    """The sequence_number of the assistant message must be assigned once at
+    placeholder creation and must not change during streaming patches."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Seq test"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Check sequence")
+    )
+
+    all_msgs = list(store.messages.values())
+    assistant_msgs = [m for m in all_msgs if m.role == "assistant" and m.thread_external_id == thread.external_id]
+    assert len(assistant_msgs) == 1
+
+    # The user message gets sequence 1, assistant gets sequence 2.
+    user_msg = next(m for m in all_msgs if m.role == "user" and m.thread_external_id == thread.external_id)
+    assert user_msg.sequence_number == 1
+    assert assistant_msgs[0].sequence_number == 2
+
+    # The thread sequence counter should be exactly 2 (not higher from
+    # streaming patches).
+    assert store._thread_sequences[thread.external_id] == 2

--- a/agent/tests/test_streaming_traces_integration.py
+++ b/agent/tests/test_streaming_traces_integration.py
@@ -1,0 +1,449 @@
+"""
+Integration tests verifying that streaming persistence (Issue #33) and
+reasoning traces (Issue #20) coexist correctly after the rebase merge.
+
+These tests exercise the interaction between the two features that is NOT
+covered by the individual test suites:
+
+  - test_runtime_service.py  → streaming persistence only (no trace assertions)
+  - test_runtime_traces.py   → trace pipeline only (no streaming message assertions)
+
+Success States
+==============
+  - A completed text run has exactly one assistant message with status="final"
+    AND at least PLANNING + THINKING + ARTIFACT_GENERATION + RUN_COMPLETED traces.
+  - A completed tool-aware run has exactly one assistant message with status="final"
+    AND at least PLANNING + TOOL_SELECTION + TOOL_COMPLETION + RUN_COMPLETED traces.
+  - Traces and the streaming assistant message appear together in ThreadStateResponse.
+  - The assistant message sequence_number is stable (not inflated by trace emissions).
+  - An errored text run has exactly one assistant message (finalized with error text)
+    AND a RUN_ERROR trace.
+  - The API-level /runs response includes both a single assistant message in thread
+    state and traces in the response body.
+
+Failure States
+==============
+  - Two assistant message rows for the same run → streaming upsert is broken.
+  - Zero traces for a completed run → trace pipeline is broken.
+  - Missing RUN_COMPLETED trace → _finalize_successful_run skipped trace emission.
+  - Inflated sequence_number → streaming patches are advancing the counter.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+import runtime.service as runtime_service
+from runtime.anthropic_adapter import AgentTurnResult, ToolTrace
+from runtime.contracts import (
+    ApprovalDecisionRequest,
+    ApprovalStatus,
+    RunCreateRequest,
+    ThreadCreateRequest,
+    TraceStepKind,
+)
+from runtime.policy import ActionClass, ApprovalPolicy, ToolAction
+from runtime.service import AgentRuntimeService
+from runtime.store import InMemoryRuntimeStore
+
+
+# ---------------------------------------------------------------------------
+# Fake adapters
+# ---------------------------------------------------------------------------
+
+class FakeAdapter:
+    model = "fake-model"
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        _ = (system_prompt, max_tokens)
+        yield f"Partial: {user_prompt[:15]}"
+        yield f"Done: {user_prompt[:15]}"
+
+
+class ErrorAdapter:
+    """Adapter that raises on the second delta to test error + trace interaction."""
+    model = "fake-error-model"
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        _ = (system_prompt, max_tokens)
+        yield "Starting..."
+        raise RuntimeError("Simulated streaming failure")
+
+
+class FakeToolAwareAdapter:
+    model = "fake-agent-sdk"
+
+    def __init__(self, result: AgentTurnResult | list[AgentTurnResult]) -> None:
+        if isinstance(result, list):
+            self._results = list(result)
+        else:
+            self._results = [result]
+        self.calls: list[dict[str, object]] = []
+
+    async def run_agent(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_turns: int = 6,
+    ) -> AgentTurnResult:
+        self.calls.append(
+            {
+                "user_prompt": user_prompt,
+                "system_prompt": system_prompt,
+                "max_turns": max_turns,
+            }
+        )
+        return self._results.pop(0)
+
+    async def stream_text(
+        self,
+        *,
+        user_prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = 900,
+    ) -> AsyncIterator[str]:
+        _ = (user_prompt, system_prompt, max_tokens)
+        yield "Approved tool executed"
+        yield "Approved tool executed successfully"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _trace_kinds(traces) -> list[str]:
+    return [t.kind.value if hasattr(t.kind, "value") else t.kind for t in traces]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Text run — streaming message + traces coexist
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_text_run_has_single_final_message_and_traces() -> None:
+    """A completed text run produces exactly one assistant message (status=final)
+    AND the expected trace sequence in the same ThreadStateResponse."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Integration text"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Summarize the agenda")
+    )
+
+    assert response.run.status.value == "completed"
+
+    # --- Streaming message assertions ---
+    state = await service.get_thread_state(thread.external_id)
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1, f"Expected 1 assistant message, got {len(assistant_msgs)}"
+    assert assistant_msgs[0].status == "final"
+    assert assistant_msgs[0].plain_text  # non-empty
+
+    # --- Trace assertions ---
+    assert len(state.traces) >= 3, f"Expected at least 3 traces, got {len(state.traces)}"
+    kinds = _trace_kinds(state.traces)
+    assert "planning" in kinds, "Missing PLANNING trace"
+    assert "thinking" in kinds, "Missing THINKING trace"
+    assert "run_completed" in kinds, "Missing RUN_COMPLETED trace"
+    assert "artifact_generation" in kinds, "Missing ARTIFACT_GENERATION trace"
+
+    # --- Response-level traces also present ---
+    assert len(response.traces) >= 3
+    resp_kinds = _trace_kinds(response.traces)
+    assert "planning" in resp_kinds
+    assert "run_completed" in resp_kinds
+
+
+@pytest.mark.asyncio
+async def test_text_run_sequence_not_inflated_by_traces() -> None:
+    """Trace emissions must not inflate the assistant message sequence_number.
+    User=seq1, assistant=seq2 — regardless of how many traces were emitted."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Seq + traces"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Hello")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    user_msg = next(m for m in state.messages if m.role == "user")
+    assistant_msg = next(m for m in state.messages if m.role == "assistant")
+
+    assert user_msg.sequence_number == 1
+    assert assistant_msg.sequence_number == 2
+    # Message sequence counter should be exactly 2
+    assert store._thread_sequences[thread.external_id] == 2
+    # But traces should exist (they use a separate counter)
+    assert len(state.traces) >= 3
+    # Trace sequence counter is separate and higher
+    trace_seqs = [t.sequence_number for t in state.traces]
+    assert all(s >= 1 for s in trace_seqs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tool-aware run — streaming message + traces coexist
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tool_aware_run_has_single_final_message_and_traces() -> None:
+    """A completed tool-aware run produces exactly one assistant message
+    AND tool-related traces in the same ThreadStateResponse."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                text_deltas=["Checking dashboard", "Summary ready"],
+                final_text="Attendance: 42 attendees",
+                tool_traces=[
+                    ToolTrace(
+                        name="get_attendance_dashboard",
+                        tool_input={},
+                        tool_use_id="tool_1",
+                        result={"totals": {"events_tracked": 2}},
+                    )
+                ],
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Integration tool"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="How is attendance?")
+    )
+
+    assert response.run.status.value == "completed"
+
+    state = await service.get_thread_state(thread.external_id)
+
+    # --- Streaming message assertions ---
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+    assert assistant_msgs[0].plain_text == "Attendance: 42 attendees"
+
+    # --- Trace assertions ---
+    kinds = _trace_kinds(state.traces)
+    assert "planning" in kinds
+    assert "tool_selection" in kinds, "Missing TOOL_SELECTION trace"
+    assert "tool_completion" in kinds, "Missing TOOL_COMPLETION trace"
+    assert "run_completed" in kinds
+
+    # Verify tool detail_json
+    tool_sel = [t for t in state.traces if t.kind.value == "tool_selection"]
+    assert len(tool_sel) >= 1
+    detail = json.loads(tool_sel[0].detail_json)
+    assert detail["tool"] == "get_attendance_dashboard"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Error run — streaming message finalized + error trace
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_error_run_has_finalized_message_and_error_trace() -> None:
+    """When streaming fails mid-run, the assistant message is finalized with
+    error text AND a RUN_ERROR trace is emitted."""
+    store = InMemoryRuntimeStore()
+    service = AgentRuntimeService(
+        store=store,
+        adapter=ErrorAdapter(),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Error integration"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Trigger error")
+    )
+
+    assert response.run.status.value == "error"
+
+    state = await service.get_thread_state(thread.external_id)
+
+    # --- Streaming message assertions ---
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1, "Error path should still have exactly one assistant message"
+    assert assistant_msgs[0].status == "final"
+
+    # --- Trace assertions ---
+    kinds = _trace_kinds(state.traces)
+    assert "planning" in kinds
+    assert "run_error" in kinds, "Missing RUN_ERROR trace on streaming failure"
+
+    # The error trace should mention the failure
+    error_traces = [t for t in state.traces if t.kind.value == "run_error"]
+    assert len(error_traces) >= 1
+    assert "streaming failure" in error_traces[0].summary.lower() or "failed" in error_traces[0].summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Approval flow — streaming + traces across pause/resume
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_approval_flow_has_streaming_message_and_traces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A write-tool run that pauses for approval, then resumes, should produce
+    exactly one assistant message AND the full trace sequence including
+    APPROVAL_PAUSE, APPROVAL_RESOLUTION, TOOL_START, TOOL_COMPLETION, RUN_COMPLETED."""
+    executed: list[tuple[str, dict]] = []
+
+    async def fake_execute_tool_call(tool_name: str, tool_input: dict) -> dict:
+        executed.append((tool_name, tool_input))
+        return {"_id": tool_input["event_id"], "status": "confirmed"}
+
+    monkeypatch.setattr(runtime_service, "execute_tool_call", fake_execute_tool_call)
+
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeToolAwareAdapter(
+            AgentTurnResult(
+                tool_traces=[
+                    ToolTrace(
+                        name="update_event_safe",
+                        tool_input={"event_id": "evt_1", "status": "confirmed"},
+                        tool_use_id="tool_2",
+                    )
+                ],
+                blocked_action=ToolAction(
+                    name="update_event_safe",
+                    action_class=ActionClass.WRITE,
+                    payload={"tool_input": {"event_id": "evt_1", "status": "confirmed"}},
+                ),
+            )
+        ),
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Approval integration"))
+    response = await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Confirm the event")
+    )
+
+    assert response.run.status.value == "paused_approval"
+
+    # At pause: should have traces including APPROVAL_PAUSE
+    pause_kinds = _trace_kinds(response.traces)
+    assert "approval_pause" in pause_kinds
+
+    # At pause: streaming message should exist (finalized before pause)
+    state = await service.get_thread_state(thread.external_id)
+    assistant_msgs = [m for m in state.messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].status == "final"
+
+    # Approve
+    approval = state.approvals[0]
+    decision = await service.submit_approval(
+        approval.external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.APPROVED),
+    )
+
+    assert decision.run.status.value == "completed"
+    assert len(executed) == 1
+
+    # After approval: full trace sequence
+    full_state = await service.get_thread_state(thread.external_id)
+    full_kinds = _trace_kinds(full_state.traces)
+    assert "approval_resolution" in full_kinds
+    assert "tool_start" in full_kinds
+    assert "tool_completion" in full_kinds
+    assert "run_completed" in full_kinds
+
+    # After approval: should have assistant messages from both phases
+    # (the tool-aware phase + the post-approval text run)
+    final_assistant_msgs = [m for m in full_state.messages if m.role == "assistant"]
+    assert len(final_assistant_msgs) >= 1
+    # All assistant messages should be finalized
+    for msg in final_assistant_msgs:
+        assert msg.status == "final", f"Assistant message {msg.external_id} has status={msg.status}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: API-level integration — response includes both traces and correct
+#        thread state with streaming-persisted messages
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_api_response_includes_traces_and_single_assistant_message() -> None:
+    """The /runs API response should include traces, and the subsequent
+    /threads/{id} response should show a single final assistant message."""
+    from fastapi.testclient import TestClient
+    from runtime.api import build_app
+
+    service = AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+    )
+    app = build_app(service)
+    client = TestClient(app)
+
+    # Create thread
+    thread_resp = client.post(
+        "/agent/threads",
+        json={"channel": "web", "title": "API Integration"},
+    )
+    assert thread_resp.status_code == 200
+    thread_id = thread_resp.json()["external_id"]
+
+    # Start a non-approval run (simple text)
+    run_resp = client.post(
+        "/agent/runs",
+        json={
+            "thread_id": thread_id,
+            "input_text": "Summarize the agenda",
+            "trigger_source": "web",
+        },
+    )
+    assert run_resp.status_code == 200
+    run_body = run_resp.json()
+
+    # Run should be completed
+    assert run_body["run"]["status"] == "completed"
+
+    # Traces should be present in the response
+    assert "traces" in run_body
+    assert len(run_body["traces"]) >= 3
+    trace_kinds = [t["kind"] for t in run_body["traces"]]
+    assert "planning" in trace_kinds
+    assert "run_completed" in trace_kinds
+
+    # Thread state should have a single final assistant message
+    state_resp = client.get(f"/agent/threads/{thread_id}")
+    assert state_resp.status_code == 200
+    state_body = state_resp.json()
+
+    assistant_msgs = [m for m in state_body["messages"] if m["role"] == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0]["status"] == "final"
+    assert assistant_msgs[0]["plain_text"]  # non-empty
+
+    # Thread state should also include traces
+    assert "traces" in state_body
+    assert len(state_body["traces"]) >= 3

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 import type { AgentMessage, AgentApproval, AgentThread, AgentTraceStep } from "./types";
 import { MessageBubble } from "./MessageBubble";
 import { ApprovalCard } from "./ApprovalCard";
@@ -9,9 +11,6 @@ import { AgentInput } from "./AgentInput";
 import { TraceRail } from "./TraceRail";
 import {
   createThread,
-  getThreadState,
-  getThreadMessages,
-  getThreadApprovals,
   startRun,
 } from "./adapters/runtime";
 
@@ -24,6 +23,110 @@ interface ConversationTimelineProps {
   onDraftChange?: (value: string) => void;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Map Convex document shapes into the frontend AgentMessage /        */
+/*  AgentApproval / AgentTraceStep types so existing rendering         */
+/*  components stay stable.                                            */
+/* ------------------------------------------------------------------ */
+
+type ConvexMessage = {
+  external_id: string;
+  thread_id: string;
+  role: string;
+  status?: string;
+  plain_text?: string | null;
+  content_blocks: Array<{
+    kind: string;
+    label?: string | null;
+    text?: string | null;
+    mime_type?: string | null;
+    data_json?: string | null;
+    url?: string | null;
+  }>;
+  created_at: number;
+};
+
+type ConvexApproval = {
+  external_id: string;
+  thread_id: string;
+  run_id: string;
+  title: string;
+  payload_json?: string | null;
+  status: string;
+  risk_level: string;
+  requested_at: number;
+};
+
+type ConvexTrace = {
+  external_id: string;
+  run_id: string;
+  kind: string;
+  sequence_number: number;
+  summary: string;
+  detail_json?: string | null;
+  status: string;
+  created_at: number;
+};
+
+function mapConvexMessage(msg: ConvexMessage): AgentMessage {
+  const content = msg.content_blocks.map((block) => {
+    if (block.kind === "text" || block.kind === "markdown") {
+      return {
+        type: "text" as const,
+        text: block.text ?? "",
+        format: block.kind === "markdown" ? ("markdown" as const) : ("plain" as const),
+      };
+    }
+    if (block.kind === "tool_use") {
+      let input: Record<string, unknown> | undefined;
+      if (block.data_json) {
+        try { input = JSON.parse(block.data_json); } catch { /* ignore */ }
+      }
+      return { type: "tool_use" as const, name: block.label ?? "tool", input };
+    }
+    return { type: "tool_result" as const, content: block.text ?? block.label ?? block.kind };
+  });
+
+  return {
+    id: msg.external_id,
+    threadId: msg.thread_id as string,
+    role: msg.role === "tool" ? "tool" : msg.role === "user" ? "user" : "assistant",
+    content: content.length > 0 ? content : [{ type: "text", text: msg.plain_text ?? "" }],
+    createdAt: msg.created_at,
+    isStreaming: msg.status === "streaming",
+  };
+}
+
+function mapConvexApproval(a: ConvexApproval): AgentApproval {
+  let proposedPayload: Record<string, unknown> = {};
+  if (a.payload_json) {
+    try { proposedPayload = JSON.parse(a.payload_json); } catch { /* ignore */ }
+  }
+  return {
+    id: a.external_id,
+    threadId: a.thread_id as string,
+    runId: a.run_id as string,
+    requestedAction: a.title,
+    riskLevel: a.risk_level as AgentApproval["riskLevel"],
+    proposedPayload,
+    status: a.status as AgentApproval["status"],
+    createdAt: a.requested_at,
+  };
+}
+
+function mapConvexTrace(t: ConvexTrace): AgentTraceStep {
+  return {
+    id: t.external_id,
+    runId: t.run_id as string,
+    kind: t.kind as AgentTraceStep["kind"],
+    sequenceNumber: t.sequence_number,
+    summary: t.summary,
+    detailJson: t.detail_json,
+    status: t.status,
+    createdAt: t.created_at,
+  };
+}
+
 export function ConversationTimeline({
   thread,
   onArtifactsChange,
@@ -32,49 +135,60 @@ export function ConversationTimeline({
   draftValue,
   onDraftChange,
 }: ConversationTimelineProps) {
-  const [messages, setMessages] = useState<AgentMessage[]>([]);
-  const [approvals, setApprovals] = useState<AgentApproval[]>([]);
-  const [traces, setTraces] = useState<AgentTraceStep[]>([]);
-  const [traceCollapsed, setTraceCollapsed] = useState(true);
-  const [streamingText, setStreamingText] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  const [traceCollapsed, setTraceCollapsed] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
   const threadIdRef = useRef<string | null>(null);
 
-  async function refreshThreadState(threadId: string) {
-    const state = await getThreadState(threadId);
-    if (threadIdRef.current !== threadId) return;
-    setMessages(state.messages);
-    setApprovals(state.approvals);
-    setTraces(state.traces ?? []);
-    setLoaded(true);
-  }
+  // Reactive Convex query: automatically updates when the backend patches
+  // messages, approvals, traces, or run status via append_message / upsert_*.
+  const threadState = useQuery(
+    api.agentState.getThreadState,
+    thread?.id ? { external_id: thread.id } : "skip",
+  );
+
+  // Derive messages, approvals, and traces from the reactive query result.
+  const messages: AgentMessage[] = threadState
+    ? (threadState.messages as unknown as ConvexMessage[]).map(mapConvexMessage)
+    : [];
+
+  const approvals: AgentApproval[] = threadState
+    ? (threadState.approvals as unknown as ConvexApproval[]).map(mapConvexApproval)
+    : [];
+
+  const traces: AgentTraceStep[] = threadState
+    ? (threadState.traces as unknown as ConvexTrace[]).map(mapConvexTrace)
+    : [];
+
+  const loaded = thread ? threadState !== undefined : true;
+
+  // Detect run completion to clear the running flag and refresh artifacts.
+  const runs = threadState?.runs ?? [];
+  const latestRun = runs[0] as { status?: string } | undefined;
+  const latestRunStatus = latestRun?.status;
 
   useEffect(() => {
-    if (!thread) {
-      threadIdRef.current = null;
-      setMessages([]);
-      setApprovals([]);
-      setTraces([]);
-      setLoaded(true);
-      return;
+    if (!isRunning) return;
+    if (
+      latestRunStatus === "completed" ||
+      latestRunStatus === "error" ||
+      latestRunStatus === "paused_approval"
+    ) {
+      setIsRunning(false);
+      onArtifactsChange?.(thread?.id);
     }
+  }, [latestRunStatus, isRunning, thread?.id, onArtifactsChange]);
 
-    if (thread.id === threadIdRef.current) return;
-    threadIdRef.current = thread.id;
-    setLoaded(false);
-    setMessages([]);
-    setApprovals([]);
-    setTraces([]);
-    setStreamingText(null);
-
-    void refreshThreadState(thread.id);
+  // Keep threadIdRef in sync for scroll behavior.
+  useEffect(() => {
+    threadIdRef.current = thread?.id ?? null;
   }, [thread]);
 
+  // Auto-scroll when messages change or while streaming.
+  const streamingMessage = messages.find((m) => m.isStreaming);
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length, streamingText]);
+  }, [messages.length, streamingMessage?.id]);
 
   async function handleSend(text: string) {
     if (isRunning) return;
@@ -84,37 +198,25 @@ export function ConversationTimeline({
       workingThread = await createThread();
       onThreadCreated?.(workingThread);
       threadIdRef.current = workingThread.id;
-      setLoaded(true);
-      setMessages([]);
-      setApprovals([]);
-      setTraces([]);
     }
 
     setIsRunning(true);
-    setStreamingText("");
     setTraceCollapsed(true);
 
-    const optimisticUser: AgentMessage = {
-      id: `opt-user-${Date.now()}`,
-      threadId: workingThread.id,
-      role: "user",
-      content: [{ type: "text", text }],
-      createdAt: Date.now(),
-    };
-    setMessages((prev) => [...prev, optimisticUser]);
-
     try {
-      await startRun(workingThread.id, text, (chunk) => setStreamingText(chunk));
-      // After run completes, refresh full state to get traces, messages, approvals
-      await refreshThreadState(workingThread.id);
-      onArtifactsChange?.(workingThread.id);
-    } finally {
+      // Use workingThread.id (not thread.id) so the first send from an
+      // empty /agent state uses the just-created thread id.
+      await startRun(workingThread.id, text);
+    } catch {
       setIsRunning(false);
-      setStreamingText(null);
     }
+    // isRunning is cleared reactively when the Convex run status changes.
   }
 
   const pendingApprovals = approvals.filter((a) => a.status === "pending");
+
+  // Check if there is a streaming assistant message being patched live.
+  const hasStreamingBubble = messages.some((m) => m.isStreaming);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -135,29 +237,17 @@ export function ConversationTimeline({
               <MessageBubble key={msg.id} message={msg} />
             ))}
 
-            {isRunning && streamingText !== null && (
+            {/* Show thinking dots only while running and no streaming bubble yet */}
+            {isRunning && !hasStreamingBubble && (
               <div className="flex gap-3">
                 <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A]">
                   <span className="text-[9px] font-bold text-white">AI</span>
                 </div>
                 <div className="max-w-[78%]">
                   <div className="rounded-[12px] rounded-tl-[4px] bg-[#F4F4F4] px-3.5 py-2.5 text-[13.5px] leading-[1.55] text-[#111111]">
-                    {streamingText || (
-                      <span className="flex items-center gap-1.5">
-                        <ThinkingDots />
-                      </span>
-                    )}
-                    {streamingText && (
-                      <>
-                        {" "}
-                        <span
-                          className="inline-block h-[13px] w-[2px] translate-y-[1px] rounded-full bg-[#555555] opacity-60"
-                          style={{
-                            animation: "cursorBlink 900ms ease-in-out infinite",
-                          }}
-                        />
-                      </>
-                    )}
+                    <span className="flex items-center gap-1.5">
+                      <ThinkingDots />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -168,7 +258,6 @@ export function ConversationTimeline({
                 key={approval.id}
                 approval={approval}
                 onDecision={async () => {
-                  await refreshThreadState(thread.id);
                   onArtifactsChange?.();
                 }}
               />
@@ -196,13 +285,6 @@ export function ConversationTimeline({
         value={draftValue}
         onValueChange={onDraftChange}
       />
-
-      <style>{`
-        @keyframes cursorBlink {
-          0%, 100% { opacity: 0.6; }
-          50% { opacity: 0; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/fe+convex/components/agent/MessageBubble.tsx
+++ b/fe+convex/components/agent/MessageBubble.tsx
@@ -12,7 +12,7 @@ interface MessageBubbleProps {
 export function MessageBubble({ message, streamingText }: MessageBubbleProps) {
   const isUser = message.role === "user";
   const isTool = message.role === "tool";
-  const isStreaming = !!streamingText;
+  const isStreaming = !!streamingText || !!message.isStreaming;
 
   if (isTool) {
     return <ToolResultRow message={message} />;
@@ -33,6 +33,7 @@ export function MessageBubble({ message, streamingText }: MessageBubbleProps) {
             block={block}
             isUser={isUser}
             streamingText={i === message.content.length - 1 ? streamingText : undefined}
+            isMessageStreaming={i === message.content.length - 1 ? message.isStreaming : undefined}
           />
         ))}
 
@@ -56,14 +57,16 @@ function ContentBlockView({
   block,
   isUser,
   streamingText,
+  isMessageStreaming,
 }: {
   block: ContentBlock;
   isUser: boolean;
   streamingText?: string;
+  isMessageStreaming?: boolean;
 }) {
   if (block.type === "text") {
     const text = streamingText ?? block.text;
-    const isStreaming = !!streamingText;
+    const isStreaming = !!streamingText || !!isMessageStreaming;
     return (
       <div
         className={`rounded-[12px] px-3.5 py-2.5 text-[13.5px] leading-[1.55] ${

--- a/fe+convex/components/agent/ThreadRail.tsx
+++ b/fe+convex/components/agent/ThreadRail.tsx
@@ -8,8 +8,9 @@ import {
   type KeyboardEvent,
 } from "react";
 import { MessageSquare, MoreHorizontal, Plus, Zap } from "lucide-react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 import type { AgentThread } from "./types";
-import { listThreads } from "./adapters/runtime";
 
 interface ThreadRailProps {
   activeThreadId: string | null;
@@ -30,6 +31,27 @@ function timeAgo(ts: number): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
+type ConvexThread = {
+  external_id: string;
+  channel: string;
+  title?: string | null;
+  summary?: string | null;
+  last_message_at?: number | null;
+  last_run_started_at?: number | null;
+  updated_at: number;
+};
+
+function mapConvexThread(t: ConvexThread): AgentThread {
+  return {
+    id: t.external_id,
+    title: t.title ?? "New conversation",
+    channel: t.channel as AgentThread["channel"],
+    lastMessage: t.summary ?? undefined,
+    lastActivityAt:
+      t.last_message_at ?? t.last_run_started_at ?? t.updated_at,
+  };
+}
+
 export function ThreadRail({
   activeThreadId,
   activeThread,
@@ -38,8 +60,17 @@ export function ThreadRail({
   onRenameThread,
   onDeleteThread,
 }: ThreadRailProps) {
-  const [threads, setThreads] = useState<AgentThread[]>([]);
-  const [loaded, setLoaded] = useState(false);
+  // Reactive Convex query replaces the one-shot listThreads() fetch.
+  const rawThreads = useQuery(api.agentState.listThreads, { limit: 50 });
+  const threads: AgentThread[] = useMemo(
+    () =>
+      rawThreads
+        ? (rawThreads as unknown as ConvexThread[]).map(mapConvexThread)
+        : [],
+    [rawThreads],
+  );
+  const loaded = rawThreads !== undefined;
+
   const [openMenuThreadId, setOpenMenuThreadId] = useState<string | null>(null);
   const [openMenuPosition, setOpenMenuPosition] = useState<{
     top: number;
@@ -51,22 +82,8 @@ export function ThreadRail({
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
   const [busyThreadId, setBusyThreadId] = useState<string | null>(null);
-  const mounted = useRef(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const editInputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    mounted.current = true;
-    listThreads().then((data) => {
-      if (mounted.current) {
-        setThreads(data);
-        setLoaded(true);
-      }
-    });
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     function handlePointerDown(event: MouseEvent) {
@@ -137,11 +154,7 @@ export function ThreadRail({
     setBusyThreadId(threadId);
     try {
       await onRenameThread(threadId, nextTitle);
-      setThreads((prev) =>
-        prev.map((thread) =>
-          thread.id === threadId ? { ...thread, title: nextTitle } : thread,
-        ),
-      );
+      // Thread list will update reactively via Convex query.
       cancelRename();
     } finally {
       setBusyThreadId(null);
@@ -152,7 +165,7 @@ export function ThreadRail({
     setBusyThreadId(threadId);
     try {
       await onDeleteThread(threadId);
-      setThreads((prev) => prev.filter((thread) => thread.id !== threadId));
+      // Thread list will update reactively via Convex query.
       if (editingThreadId === threadId) {
         cancelRename();
       }
@@ -317,14 +330,14 @@ export function ThreadRail({
                       }
                       setOpenMenuThreadId(nextOpen ? thread.id : null);
                     }}
-                    className={`absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-[6px] border border-transparent text-[#888888] transition-colors hover:bg-[#EDEDED] hover:text-[#222222] ${
+                    className={`absolute right-2 top-3 flex h-6 w-6 items-center justify-center rounded-[5px] text-[#BBBBBB] transition-all duration-100 ${
                       menuOpen
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100"
+                        ? "bg-[#E0E0E0] text-[#555555]"
+                        : "opacity-0 hover:bg-[#E0E0E0] hover:text-[#555555] group-hover:opacity-100"
                     }`}
-                    aria-label="Thread actions"
+                    aria-label="Thread options"
                   >
-                    <MoreHorizontal className="h-3.5 w-3.5" strokeWidth={1.9} />
+                    <MoreHorizontal className="h-3.5 w-3.5" strokeWidth={2} />
                   </button>
                 </li>
               );
@@ -333,42 +346,42 @@ export function ThreadRail({
         )}
       </div>
 
-      {openMenuThread && editingThreadId !== openMenuThread.id ? (
+      {openMenuThread && (
         <div
           ref={menuRef}
-          className="fixed z-[9999] w-[132px] overflow-hidden rounded-[8px] border border-[#E5E5E5] bg-[#FFFFFF] py-1 shadow-[0_8px_20px_rgba(0,0,0,0.08)]"
-          style={{ top: openMenuPosition.top, left: openMenuPosition.left }}
+          className="fixed z-50 w-[132px] overflow-hidden rounded-[8px] border border-[#E0E0E0] bg-[#FFFFFF] py-1 shadow-[0_4px_12px_rgba(0,0,0,0.08)]"
+          style={{
+            top: openMenuPosition.top,
+            left: openMenuPosition.left,
+            animation: "menuFadeIn 120ms ease-out both",
+          }}
         >
           <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              startRename(openMenuThread);
-            }}
-            className="block w-full px-4 py-2 text-left text-[12px] text-[#222222] transition-colors hover:bg-[#F4F4F4]"
+            onClick={() => startRename(openMenuThread)}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12.5px] text-[#333333] transition-colors duration-75 hover:bg-[#F4F4F4]"
           >
             Rename
           </button>
           <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              void handleDelete(openMenuThread.id);
-            }}
-            className="block w-full px-4 py-2 text-left text-[12px] text-red-600 transition-colors hover:bg-[#F4F4F4]"
+            onClick={() => void handleDelete(openMenuThread.id)}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12.5px] text-[#CC3333] transition-colors duration-75 hover:bg-[#FFF0F0]"
           >
             Delete
           </button>
         </div>
-      ) : null}
+      )}
 
       <style>{`
-        @keyframes threadItemIn {
-          from { opacity: 0; transform: translateY(4px); }
-          to   { opacity: 1; transform: translateY(0); }
+        @keyframes menuFadeIn {
+          from { opacity: 0; transform: translateY(-4px) scale(0.97); }
+          to   { opacity: 1; transform: translateY(0) scale(1); }
+        }
+        @keyframes threadItemEnter {
+          from { opacity: 0; transform: translateX(-6px); }
+          to   { opacity: 1; transform: translateX(0); }
         }
         .thread-item-enter {
-          animation: threadItemIn 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
+          animation: threadItemEnter 200ms ease-out;
         }
       `}</style>
     </aside>
@@ -377,15 +390,12 @@ export function ThreadRail({
 
 function ThreadSkeletons() {
   return (
-    <div className="space-y-px px-2 py-1">
-      {[80, 65, 72].map((w, i) => (
-        <div key={i} className="rounded-[8px] px-3 py-2.5">
-          <div className="h-2.5 w-3/4 animate-pulse rounded-full bg-[#E8E8E8]" />
-          <div
-            className="mt-1.5 animate-pulse rounded-full bg-[#EFEFEF]"
-            style={{ height: 9, width: `${w}%` }}
-          />
-        </div>
+    <div className="space-y-1 px-2">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="h-[52px] animate-pulse rounded-[8px] bg-[#F0F0F0]"
+        />
       ))}
     </div>
   );
@@ -393,13 +403,13 @@ function ThreadSkeletons() {
 
 function EmptyState({ onNew }: { onNew: () => void }) {
   return (
-    <div className="px-4 py-8 text-center">
-      <p className="text-[12px] text-[#BBBBBB]">No conversations yet.</p>
+    <div className="flex flex-col items-center gap-3 px-4 pt-8 text-center">
+      <p className="text-[12.5px] text-[#BBBBBB]">No conversations yet.</p>
       <button
         onClick={onNew}
-        className="mt-3 text-[12px] font-medium text-[#555555] underline-offset-2 hover:underline"
+        className="rounded-[6px] border border-[#E0E0E0] px-3 py-1.5 text-[12px] font-medium text-[#555555] transition-colors duration-100 hover:bg-[#F4F4F4]"
       >
-        Start one
+        Start a conversation
       </button>
     </div>
   );

--- a/fe+convex/components/agent/adapters/runtime.ts
+++ b/fe+convex/components/agent/adapters/runtime.ts
@@ -42,6 +42,7 @@ type BackendMessage = {
   external_id: string;
   thread_external_id: string;
   role: string;
+  status?: string | null;
   plain_text?: string | null;
   content_blocks: BackendContentBlock[];
   created_at: number;
@@ -93,6 +94,7 @@ type RunStreamEvent = {
   data: Record<string, unknown>;
 };
 
+// Kept for backward compatibility with existing web callers.
 type RunWithEventsResponse = {
   run: BackendRun & { error_message?: string | null };
   events: RunStreamEvent[];
@@ -174,6 +176,7 @@ function mapMessage(message: BackendMessage): AgentMessage {
         ? content
         : [{ type: "text", text: message.plain_text ?? "" }],
     createdAt: message.created_at,
+    isStreaming: message.status === "streaming",
   };
 }
 
@@ -239,28 +242,6 @@ function mapRun(run: BackendRun): AgentRun {
   };
 }
 
-function typewriterReveal(text: string, onChunk: (text: string) => void): Promise<void> {
-  return new Promise((resolve) => {
-    const words = text.split(" ");
-    let revealed = "";
-    let i = 0;
-    // Vary speed slightly so it feels natural, not robotic
-    const step = () => {
-      if (i >= words.length) {
-        resolve();
-        return;
-      }
-      revealed += (i === 0 ? "" : " ") + words[i];
-      onChunk(revealed);
-      i++;
-      // ~60-120ms per word feels natural for reading speed
-      const delay = 60 + Math.random() * 40;
-      setTimeout(step, delay);
-    };
-    step();
-  });
-}
-
 export async function listThreads(): Promise<AgentThread[]> {
   const threads = await request<BackendThread[]>("/threads");
   return threads.map(mapThread);
@@ -310,10 +291,16 @@ export async function createThread(title?: string): Promise<AgentThread> {
   return mapThread(thread);
 }
 
+/**
+ * Start a run against the backend. The backend now persists streaming assistant
+ * messages into Convex in real time, so the UI should rely on reactive
+ * `useQuery` subscriptions to render live updates rather than local typewriter
+ * replay. This function fires the POST and throws on error but does not
+ * attempt local text animation.
+ */
 export async function startRun(
   threadId: string,
   userMessage: string,
-  onChunk: (text: string) => void
 ): Promise<void> {
   const result = await request<RunWithEventsResponse>("/runs", {
     method: "POST",
@@ -327,17 +314,6 @@ export async function startRun(
 
   if (result.run.error_message) {
     throw new Error(result.run.error_message);
-  }
-
-  // Find the final assistant text from events and reveal it with a typewriter animation
-  const finalText = result.events
-    .filter((e) => e.event === "assistant.delta")
-    .map((e) => e.data.text as string)
-    .filter(Boolean)
-    .at(-1);
-
-  if (finalText) {
-    await typewriterReveal(finalText, onChunk);
   }
 }
 

--- a/fe+convex/convex/agentState.test.ts
+++ b/fe+convex/convex/agentState.test.ts
@@ -815,4 +815,219 @@ describe("agent state persistence", () => {
       resolved_at: 60,
     });
   });
+
+  test("streaming assistant message patches one row by external_id and preserves sequence", async () => {
+    const { ctx, db } = createHarness();
+
+    const threadId = await getHandler<
+      {
+        external_id: string;
+        channel: string;
+        status: string;
+        title?: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_streaming_1",
+      channel: "web",
+      status: "active",
+      title: "Streaming thread",
+      created_at: 100,
+      updated_at: 100,
+    });
+
+    const runId = await getHandler<
+      {
+        thread_id: string;
+        external_id: string;
+        status: string;
+        trigger_source: string;
+        started_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_streaming_1",
+      status: "running",
+      trigger_source: "web",
+      started_at: 110,
+      updated_at: 110,
+    });
+
+    // 1. User message
+    await getHandler<
+      {
+        thread_id: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      external_id: "msg_user_streaming",
+      role: "user",
+      status: "complete",
+      sequence_number: 1,
+      plain_text: "Show attendance",
+      content_blocks: [{ kind: "text", text: "Show attendance" }],
+      created_at: 115,
+      updated_at: 115,
+    });
+
+    // 2. Streaming placeholder (empty text, status=streaming)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_streaming",
+      role: "assistant",
+      status: "streaming",
+      sequence_number: 2,
+      plain_text: "",
+      content_blocks: [{ kind: "text", text: "" }],
+      created_at: 120,
+      updated_at: 120,
+    });
+
+    // 3. First streaming delta patch (same external_id)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_streaming",
+      role: "assistant",
+      status: "streaming",
+      sequence_number: 2,
+      plain_text: "Partial text",
+      content_blocks: [{ kind: "text", text: "Partial text" }],
+      updated_at: 125,
+    });
+
+    // 4. Second streaming delta patch (same external_id)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_streaming",
+      role: "assistant",
+      status: "streaming",
+      sequence_number: 2,
+      plain_text: "Partial text extended",
+      content_blocks: [{ kind: "text", text: "Partial text extended" }],
+      updated_at: 130,
+    });
+
+    // 5. Finalization patch (same external_id, status=complete)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_streaming",
+      role: "assistant",
+      status: "complete",
+      sequence_number: 2,
+      plain_text: "Full answer ready",
+      content_blocks: [{ kind: "markdown", text: "Full answer ready" }],
+      updated_at: 135,
+    });
+
+    // Assertions: only one assistant message row should exist
+    const messageRows = db.rows("agent_messages");
+    const assistantRows = messageRows.filter(
+      (row) => row.role === "assistant" && row.thread_id === threadId
+    );
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]).toMatchObject({
+      external_id: "msg_assistant_streaming",
+      status: "complete",
+      plain_text: "Full answer ready",
+      sequence_number: 2,
+    });
+
+    // Total messages: 1 user + 1 assistant = 2
+    const threadMessages = messageRows.filter((row) => row.thread_id === threadId);
+    expect(threadMessages).toHaveLength(2);
+
+    // Sequence ordering preserved via getThreadState
+    const threadState = await getHandler<
+      { external_id?: string; thread_id?: string },
+      {
+        thread: Record<string, unknown>;
+        runs: Array<Record<string, unknown>>;
+        messages: Array<Record<string, unknown>>;
+        artifacts: Array<Record<string, unknown>>;
+        approvals: Array<Record<string, unknown>>;
+        context_links: Array<Record<string, unknown>>;
+      }
+    >(getThreadState)(ctx as never, { external_id: "thread_streaming_1" });
+
+    expect(threadState.messages).toHaveLength(2);
+    expect(threadState.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(threadState.messages.map((m) => m.sequence_number)).toEqual([1, 2]);
+    expect(threadState.messages[1]).toMatchObject({
+      status: "complete",
+      plain_text: "Full answer ready",
+    });
+  });
 });

--- a/fe+convex/convex/agentState.test.ts
+++ b/fe+convex/convex/agentState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   appendMessage,
+  appendTrace,
   getRunState,
   getThreadState,
   listPendingApprovals,
@@ -121,6 +122,7 @@ class FakeDb {
 function installConvexHandlerAliases() {
   for (const fn of [
     appendMessage,
+    appendTrace,
     getRunState,
     getThreadState,
     listPendingApprovals,
@@ -1029,5 +1031,299 @@ describe("agent state persistence", () => {
       status: "complete",
       plain_text: "Full answer ready",
     });
+  });
+
+  test("getThreadState returns both streaming-upserted message and ordered traces together", async () => {
+    const { ctx, db } = createHarness();
+
+    // 1. Create thread
+    const threadId = await getHandler<
+      { external_id: string; channel: string; status: string; title?: string; updated_at?: number },
+      string
+    >(upsertThread)(ctx as never, {
+      external_id: "thread_combined_1",
+      channel: "web",
+      status: "active",
+      title: "Combined test",
+      updated_at: 100,
+    });
+
+    // 2. Create run
+    const runId = await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_combined_1",
+      status: "running",
+      trigger_source: "web",
+      updated_at: 110,
+    });
+
+    // 3. User message
+    await getHandler<
+      {
+        thread_id: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      external_id: "msg_user_combined",
+      role: "user",
+      status: "complete",
+      sequence_number: 1,
+      plain_text: "How is attendance?",
+      content_blocks: [{ kind: "text", text: "How is attendance?" }],
+      created_at: 115,
+      updated_at: 115,
+    });
+
+    // 4. Planning trace
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_combined_planning",
+      kind: "planning",
+      sequence_number: 1,
+      summary: "Analyzing request.",
+      status: "completed",
+      created_at: 116,
+      updated_at: 116,
+    });
+
+    // 5. Streaming assistant placeholder
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_combined",
+      role: "assistant",
+      status: "streaming",
+      sequence_number: 2,
+      plain_text: "",
+      content_blocks: [{ kind: "text", text: "" }],
+      created_at: 120,
+      updated_at: 120,
+    });
+
+    // 6. Thinking trace (emitted during streaming)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_combined_thinking",
+      kind: "thinking",
+      sequence_number: 2,
+      summary: "Generating response.",
+      status: "completed",
+      created_at: 121,
+      updated_at: 121,
+    });
+
+    // 7. Streaming delta patch
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_combined",
+      role: "assistant",
+      status: "streaming",
+      sequence_number: 2,
+      plain_text: "Partial answer",
+      content_blocks: [{ kind: "text", text: "Partial answer" }],
+      updated_at: 125,
+    });
+
+    // 8. Artifact generation trace
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        detail_json?: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_combined_artifact",
+      kind: "artifact_generation",
+      sequence_number: 3,
+      summary: "Generated artifact: Run Summary",
+      detail_json: '{"artifact_id":"art_1","kind":"report"}',
+      status: "completed",
+      created_at: 128,
+      updated_at: 128,
+    });
+
+    // 9. Finalization patch (same external_id, status=complete)
+    await getHandler<
+      {
+        thread_id: string;
+        run_id?: string;
+        external_id: string;
+        role: string;
+        status: string;
+        sequence_number: number;
+        plain_text?: string;
+        content_blocks: Array<Record<string, string>>;
+        updated_at?: number;
+      },
+      string
+    >(appendMessage)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "msg_assistant_combined",
+      role: "assistant",
+      status: "complete",
+      sequence_number: 2,
+      plain_text: "Full answer ready",
+      content_blocks: [{ kind: "markdown", text: "Full answer ready" }],
+      updated_at: 130,
+    });
+
+    // 10. Run completed trace
+    await getHandler<
+      {
+        thread_id: string;
+        run_id: string;
+        external_id: string;
+        kind: string;
+        sequence_number: number;
+        summary: string;
+        status: string;
+        created_at?: number;
+        updated_at?: number;
+      },
+      string
+    >(appendTrace)(ctx as never, {
+      thread_id: threadId,
+      run_id: runId,
+      external_id: "trace_combined_completed",
+      kind: "run_completed",
+      sequence_number: 4,
+      summary: "Run completed successfully.",
+      status: "completed",
+      created_at: 135,
+      updated_at: 135,
+    });
+
+    // 11. Mark run completed
+    await getHandler<
+      { thread_id: string; external_id: string; status: string; trigger_source: string; completed_at?: number; updated_at?: number },
+      string
+    >(upsertRun)(ctx as never, {
+      thread_id: threadId,
+      external_id: "run_combined_1",
+      status: "completed",
+      trigger_source: "web",
+      completed_at: 140,
+      updated_at: 140,
+    });
+
+    // ---- Assertions: getThreadState returns both messages and traces ----
+    const threadState = await getHandler<
+      { external_id?: string; thread_id?: string },
+      {
+        thread: Record<string, unknown>;
+        runs: Array<Record<string, unknown>>;
+        messages: Array<Record<string, unknown>>;
+        traces: Array<Record<string, unknown>>;
+      }
+    >(getThreadState)(ctx as never, { external_id: "thread_combined_1" });
+
+    // Messages: exactly 2 (user + single upserted assistant)
+    expect(threadState.messages).toHaveLength(2);
+    expect(threadState.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(threadState.messages.map((m) => m.sequence_number)).toEqual([1, 2]);
+    expect(threadState.messages[1]).toMatchObject({
+      external_id: "msg_assistant_combined",
+      status: "complete",
+      plain_text: "Full answer ready",
+    });
+
+    // Traces: 4 traces in correct order
+    expect(threadState.traces).toHaveLength(4);
+    expect(threadState.traces.map((t) => t.kind)).toEqual([
+      "planning",
+      "thinking",
+      "artifact_generation",
+      "run_completed",
+    ]);
+    expect(threadState.traces.map((t) => t.sequence_number)).toEqual([1, 2, 3, 4]);
+
+    // Run is completed
+    expect(threadState.runs).toHaveLength(1);
+    expect(threadState.runs[0]).toMatchObject({ status: "completed" });
+
+    // Raw DB: only 1 assistant message row (not duplicated by streaming patches)
+    const assistantRows = db.rows("agent_messages").filter(
+      (row) => row.role === "assistant" && row.thread_id === threadId
+    );
+    expect(assistantRows).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes #33

## Summary

Implements streaming + persistence for the agent runtime so that assistant messages are written to Convex in real time and the frontend renders them reactively, eliminating the need for local typewriter animation or one-shot fetches.

## Changes

### Backend (`agent/runtime/service.py`)

- **`_begin_streaming_assistant_message()`** — creates an empty assistant `MessageRecord` with `status="streaming"` before the first delta, persisted to both the in-memory store and Convex via `append_message` (which upserts by `external_id`).
- **`_patch_streaming_assistant_message()`** — patches the same message row in place during streaming, updating `plain_text`, `content_blocks`, and `updated_at` without advancing `sequence_number`.
- **`_finalize_successful_run()`** — patches the streaming message to `status="final"` instead of creating a second assistant message row. Falls back to the legacy `_append_message` path only for non-streaming flows (e.g. rejection messages).
- Both `_execute_text_run` and `_execute_tool_aware_run` now use the placeholder → patch → finalize pattern.

### Frontend (`fe+convex/components/agent/ConversationTimeline.tsx`)

- Replaced one-shot `getThreadMessages()` fetch with `useQuery(api.agentState.getThreadState)` for reactive Convex subscriptions.
- Messages and approvals are derived from the reactive query result and mapped to existing `AgentMessage`/`AgentApproval` types.
- **Fixed new-thread send path**: uses `workingThread.id` (the just-created thread) instead of `thread.id` (which is `null` at that point).
- Run completion is detected reactively via `latestRunStatus` instead of an `onDone` callback.
- Shows thinking dots only while running and no streaming bubble exists yet.

### Frontend (`fe+convex/components/agent/ThreadRail.tsx`)

- Replaced one-shot `listThreads()` fetch with `useQuery(api.agentState.listThreads)` for reactive thread list updates.
- Thread list updates automatically when new threads are created or renamed.

### Frontend (`fe+convex/components/agent/adapters/runtime.ts`)

- Removed `typewriterReveal` and local text animation from `startRun`.
- `startRun` now fires the POST and throws on error; the UI relies on reactive Convex state for rendering.
- `RunWithEventsResponse` type kept for backward compatibility.

### Frontend (`fe+convex/components/agent/MessageBubble.tsx`)

- `isStreaming` now also checks `message.isStreaming` (not just the explicit `streamingText` prop), so Convex-persisted streaming messages show the cursor.
- `ContentBlockView` receives `isMessageStreaming` to propagate the flag.

### Convex (`fe+convex/convex/agentState.ts`)

- No changes needed — `appendMessage` already upserts by `external_id`, which is exactly the behavior needed for streaming patches.

## Tests

### Python (`agent/tests/test_runtime_service.py`) — 5 new tests

| Test | What it verifies |
|------|-----------------|
| `test_streaming_placeholder_created_before_first_delta` | Placeholder created before first delta, patched to final |
| `test_streaming_finalization_patches_same_message_not_new_row` | Only one assistant message row exists after finalization |
| `test_tool_aware_streaming_placeholder_patched_in_place` | Tool-aware runs also use placeholder → patch pattern |
| `test_completed_run_shows_final_assistant_bubble` | Final assistant bubble visible after run completion |
| `test_sequence_number_not_advanced_during_streaming` | Sequence counter stays at 2 (user=1, assistant=2) |

### Convex (`fe+convex/convex/agentState.test.ts`) — 1 new test

| Test | What it verifies |
|------|-----------------|
| `streaming assistant message patches one row by external_id and preserves sequence` | 4 calls to `appendMessage` with the same `external_id` produce exactly 1 row, final status is `complete`, sequence ordering preserved in `getThreadState` |

### Results

- **Python**: 14/14 passed (including 2 existing API tests)
- **Convex**: 4/4 passed

## Failure modes addressed

- Creating new assistant message row for every delta → **fixed**: upsert by `external_id`
- Advancing `sequence_number` during streaming → **fixed**: assigned once at placeholder creation
- Double-rendering optimistic and persisted user messages → **fixed**: no local optimistic messages
- Thread/timeline on one-shot fetches after runtime starts patching live data → **fixed**: `useQuery` subscriptions
- `thread.id` null on first send from empty `/agent` state → **fixed**: `workingThread.id`
