### PR TITLE
[frontend] Render stable incremental markdown during streaming

### DIFF
--- a/fe+convex/components/agent/MessageBubble.tsx
+++ b/fe+convex/components/agent/MessageBubble.tsx
@@ -3,6 +3,7 @@
 import { Wrench } from "lucide-react";
 import type { AgentMessage, ContentBlock } from "./types";
 import { RichAgentMarkdown } from "./RichAgentMarkdown";
+import { stabilizeMarkdownPreview } from "./streamingMarkdown";
 
 interface MessageBubbleProps {
   message: AgentMessage;
@@ -107,18 +108,29 @@ function AssistantTextBlock({
   text: string;
   isStreaming: boolean;
 }) {
-  if (isStreaming) {
+  if (!isStreaming) {
     return (
       <div className="text-[13.5px] leading-[1.65] text-[#111111]">
-        {text}
-        <StreamingCursor />
+        <RichAgentMarkdown markdown={text} variant="bubble" />
       </div>
     );
   }
 
+  const { stableMarkdown, unstableTail } = stabilizeMarkdownPreview(text);
+
   return (
     <div className="text-[13.5px] leading-[1.65] text-[#111111]">
-      <RichAgentMarkdown markdown={text} variant="bubble" />
+      {stableMarkdown ? (
+        <RichAgentMarkdown markdown={stableMarkdown} variant="bubble" />
+      ) : null}
+      {unstableTail ? (
+        <span className="whitespace-pre-wrap">
+          {unstableTail}
+          <StreamingCursor />
+        </span>
+      ) : (
+        <StreamingCursor />
+      )}
     </div>
   );
 }

--- a/fe+convex/components/agent/streamingMarkdown.test.ts
+++ b/fe+convex/components/agent/streamingMarkdown.test.ts
@@ -4,10 +4,10 @@
  *
  * Sections:
  *   1. basic completeness — full vs. partial lines
- *   2. fenced code blocks — open fences pin the tail
+ *   2. fenced code blocks — open fences pin the tail; closer rules per CommonMark
  *   3. headings, lists, tables — line-completeness rules
  *   4. monotonicity — already-stable content stays stable
- *   5. convergence — preview reconstructs the original input
+ *   5. convergence — `stableMarkdown + unstableTail` reconstructs the input
  */
 
 import { describe, test, expect } from "bun:test";
@@ -32,17 +32,38 @@ describe("stabilizeMarkdownPreview — basic completeness", () => {
     });
   });
 
-  test("a single newline-terminated line becomes stable", () => {
+  test("a single newline-terminated line becomes stable (newline lives in stable)", () => {
     expect(stabilizeMarkdownPreview("Hello\n")).toEqual({
-      stableMarkdown: "Hello",
+      stableMarkdown: "Hello\n",
       unstableTail: "",
     });
   });
 
   test("complete lines stabilize, trailing partial line stays in tail", () => {
     expect(stabilizeMarkdownPreview("First line\nSecond line\nThird par")).toEqual({
-      stableMarkdown: "First line\nSecond line",
+      stableMarkdown: "First line\nSecond line\n",
       unstableTail: "Third par",
+    });
+  });
+
+  test("a single bare newline stabilizes losslessly", () => {
+    expect(stabilizeMarkdownPreview("\n")).toEqual({
+      stableMarkdown: "\n",
+      unstableTail: "",
+    });
+  });
+
+  test("leading newline before partial content is preserved in the stable side", () => {
+    expect(stabilizeMarkdownPreview("\nHello")).toEqual({
+      stableMarkdown: "\n",
+      unstableTail: "Hello",
+    });
+  });
+
+  test("multiple leading newlines are all stabilized", () => {
+    expect(stabilizeMarkdownPreview("\n\n\nHello")).toEqual({
+      stableMarkdown: "\n\n\n",
+      unstableTail: "Hello",
     });
   });
 });
@@ -55,7 +76,7 @@ describe("stabilizeMarkdownPreview — fenced code blocks", () => {
   test("an open code fence pins the entire fence segment to the tail", () => {
     const raw = "intro line\n```ts\nconst x = 1\nconst y = 2";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "intro line",
+      stableMarkdown: "intro line\n",
       unstableTail: "```ts\nconst x = 1\nconst y = 2",
     });
   });
@@ -71,7 +92,7 @@ describe("stabilizeMarkdownPreview — fenced code blocks", () => {
   test("a closed fence stabilizes the full code block", () => {
     const raw = "```ts\nconst x = 1\n```\n";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "```ts\nconst x = 1\n```",
+      stableMarkdown: "```ts\nconst x = 1\n```\n",
       unstableTail: "",
     });
   });
@@ -79,7 +100,7 @@ describe("stabilizeMarkdownPreview — fenced code blocks", () => {
   test("content after a closed fence stabilizes once its line is complete", () => {
     const raw = "```ts\nfoo\n```\nAfter fence\n";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "```ts\nfoo\n```\nAfter fence",
+      stableMarkdown: "```ts\nfoo\n```\nAfter fence\n",
       unstableTail: "",
     });
   });
@@ -87,7 +108,7 @@ describe("stabilizeMarkdownPreview — fenced code blocks", () => {
   test("a second open fence pins the new fenced segment to the tail", () => {
     const raw = "```ts\nfoo\n```\nGap\n```py\nbar";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "```ts\nfoo\n```\nGap",
+      stableMarkdown: "```ts\nfoo\n```\nGap\n",
       unstableTail: "```py\nbar",
     });
   });
@@ -95,7 +116,50 @@ describe("stabilizeMarkdownPreview — fenced code blocks", () => {
   test("indented fence markers still toggle fence state", () => {
     const raw = "  ```ts\nfoo\n  ```\n";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "  ```ts\nfoo\n  ```",
+      stableMarkdown: "  ```ts\nfoo\n  ```\n",
+      unstableTail: "",
+    });
+  });
+
+  /* ────────────────────────────────────────────────────────────────────────
+   *  CommonMark closer rules — guards against false fence closure inside
+   *  an open block. Without these, "markdown-in-markdown" responses break.
+   * ──────────────────────────────────────────────────────────────────────── */
+
+  test("a line like ```ts inside an open fence does NOT close it (closer cannot have an info string)", () => {
+    // Outer 3-backtick fence opens on line 0. Line 1 is "```ts" — looks like
+    // a fence line but cannot be a closer because closers must have nothing
+    // after the backticks. The fence stays open through line 2.
+    const raw = "```\ninside ```ts looks like an opener\nstill inside\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "",
+      unstableTail: "```\ninside ```ts looks like an opener\nstill inside\n",
+    });
+  });
+
+  test("a 3-backtick line inside a 4-backtick fence does NOT close it (closer must be ≥ opener length)", () => {
+    // Outer fence is 4 backticks, so a 3-backtick line cannot close it. This
+    // is the common pattern for embedding a markdown code sample inside a
+    // markdown code sample.
+    const raw = "````\n```ts\nconst x = 1;\n```\n````\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "````\n```ts\nconst x = 1;\n```\n````\n",
+      unstableTail: "",
+    });
+  });
+
+  test("a 4-backtick line DOES close a 3-backtick fence (closer length ≥ opener length)", () => {
+    const raw = "```ts\nfoo\n````\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "```ts\nfoo\n````\n",
+      unstableTail: "",
+    });
+  });
+
+  test("trailing whitespace on a closer is allowed", () => {
+    const raw = "```ts\nfoo\n```   \n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "```ts\nfoo\n```   \n",
       unstableTail: "",
     });
   });
@@ -115,7 +179,7 @@ describe("stabilizeMarkdownPreview — markdown elements", () => {
 
   test("a complete heading line stabilizes after the newline", () => {
     expect(stabilizeMarkdownPreview("# Heading\n")).toEqual({
-      stableMarkdown: "# Heading",
+      stableMarkdown: "# Heading\n",
       unstableTail: "",
     });
   });
@@ -123,7 +187,7 @@ describe("stabilizeMarkdownPreview — markdown elements", () => {
   test("partial list item stays in the unstable tail", () => {
     const raw = "- one\n- two\n- thr";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "- one\n- two",
+      stableMarkdown: "- one\n- two\n",
       unstableTail: "- thr",
     });
   });
@@ -131,7 +195,7 @@ describe("stabilizeMarkdownPreview — markdown elements", () => {
   test("ordered list items stabilize line by line", () => {
     const raw = "1. alpha\n2. beta\n3. ga";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "1. alpha\n2. beta",
+      stableMarkdown: "1. alpha\n2. beta\n",
       unstableTail: "3. ga",
     });
   });
@@ -139,7 +203,7 @@ describe("stabilizeMarkdownPreview — markdown elements", () => {
   test("partial table row stays in the unstable tail", () => {
     const raw = "| col a | col b |\n| ----- | ----- |\n| 1 | ";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "| col a | col b |\n| ----- | ----- |",
+      stableMarkdown: "| col a | col b |\n| ----- | ----- |\n",
       unstableTail: "| 1 | ",
     });
   });
@@ -147,7 +211,7 @@ describe("stabilizeMarkdownPreview — markdown elements", () => {
   test("complete table row stabilizes once its line ends", () => {
     const raw = "| col a | col b |\n| ----- | ----- |\n| 1 | 2 |\n";
     expect(stabilizeMarkdownPreview(raw)).toEqual({
-      stableMarkdown: "| col a | col b |\n| ----- | ----- |\n| 1 | 2 |",
+      stableMarkdown: "| col a | col b |\n| ----- | ----- |\n| 1 | 2 |\n",
       unstableTail: "",
     });
   });
@@ -196,32 +260,34 @@ describe("stabilizeMarkdownPreview — monotonic stable boundary", () => {
       prevStableLen = stableMarkdown.length;
     }
   });
+
+  test("stable prefix never shrinks across a stream containing a 4-backtick markdown-in-markdown block", () => {
+    const final = "intro\n````md\n```ts\nfoo\n```\n````\nafter\n";
+    let prevStableLen = 0;
+    for (const prefix of streamPrefixes(final)) {
+      const { stableMarkdown } = stabilizeMarkdownPreview(prefix);
+      expect(stableMarkdown.length).toBeGreaterThanOrEqual(prevStableLen);
+      prevStableLen = stableMarkdown.length;
+    }
+  });
 });
 
 /* ══════════════════════════════════════════════════════════════════════════ */
 /*  5. convergence                                                           */
 /*                                                                            */
-/*  The preview must lossless-reconstruct the input: stable + boundary-\n + */
-/*  tail equals the raw stream. This guarantees no character is dropped or  */
-/*  duplicated between preview and the final rendered message.              */
+/*  The split is lossless: stableMarkdown + unstableTail equals the raw     */
+/*  stream for every input. This guarantees no character is dropped or      */
+/*  duplicated between the streaming preview and the final rendered output. */
 /* ══════════════════════════════════════════════════════════════════════════ */
 
 describe("stabilizeMarkdownPreview — convergence", () => {
-  function recombine(raw: string): string {
-    const { stableMarkdown, unstableTail } = stabilizeMarkdownPreview(raw);
-    if (!stableMarkdown) return unstableTail;
-    if (!unstableTail) {
-      // The trailing newline that separated stable from tail was consumed when
-      // tail was sliced as []. Reattach it so we recover the original input.
-      return raw.endsWith("\n") ? `${stableMarkdown}\n` : stableMarkdown;
-    }
-    return `${stableMarkdown}\n${unstableTail}`;
-  }
-
   const cases = [
     "",
     "Hello",
     "Hello\n",
+    "\n",
+    "\nHello",
+    "\n\n\nHello",
     "First\nSecond\n",
     "First\nSecond\nThird par",
     "# Heading\n\nBody text.\n",
@@ -229,11 +295,14 @@ describe("stabilizeMarkdownPreview — convergence", () => {
     "```ts\nconst x = 1\n",
     "- one\n- two\n- thr",
     "| a | b |\n| - | - |\n| 1 | 2 |\n",
+    "````\n```ts\nfoo\n```\n````\n",
+    "```\ninside ```ts looks like an opener\nstill inside\n",
   ];
 
   for (const raw of cases) {
     test(`recombines: ${JSON.stringify(raw)}`, () => {
-      expect(recombine(raw)).toBe(raw);
+      const { stableMarkdown, unstableTail } = stabilizeMarkdownPreview(raw);
+      expect(stableMarkdown + unstableTail).toBe(raw);
     });
   }
 });

--- a/fe+convex/components/agent/streamingMarkdown.test.ts
+++ b/fe+convex/components/agent/streamingMarkdown.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for stabilizeMarkdownPreview — the stable-prefix splitter that lets
+ * streaming assistant text render as markdown without churn.
+ *
+ * Sections:
+ *   1. basic completeness — full vs. partial lines
+ *   2. fenced code blocks — open fences pin the tail
+ *   3. headings, lists, tables — line-completeness rules
+ *   4. monotonicity — already-stable content stays stable
+ *   5. convergence — preview reconstructs the original input
+ */
+
+import { describe, test, expect } from "bun:test";
+import { stabilizeMarkdownPreview } from "./streamingMarkdown";
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  1. basic completeness                                                    */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe("stabilizeMarkdownPreview — basic completeness", () => {
+  test("empty input yields empty stable and tail", () => {
+    expect(stabilizeMarkdownPreview("")).toEqual({
+      stableMarkdown: "",
+      unstableTail: "",
+    });
+  });
+
+  test("partial line with no newline stays entirely in the tail", () => {
+    expect(stabilizeMarkdownPreview("Hello")).toEqual({
+      stableMarkdown: "",
+      unstableTail: "Hello",
+    });
+  });
+
+  test("a single newline-terminated line becomes stable", () => {
+    expect(stabilizeMarkdownPreview("Hello\n")).toEqual({
+      stableMarkdown: "Hello",
+      unstableTail: "",
+    });
+  });
+
+  test("complete lines stabilize, trailing partial line stays in tail", () => {
+    expect(stabilizeMarkdownPreview("First line\nSecond line\nThird par")).toEqual({
+      stableMarkdown: "First line\nSecond line",
+      unstableTail: "Third par",
+    });
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  2. fenced code blocks                                                    */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe("stabilizeMarkdownPreview — fenced code blocks", () => {
+  test("an open code fence pins the entire fence segment to the tail", () => {
+    const raw = "intro line\n```ts\nconst x = 1\nconst y = 2";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "intro line",
+      unstableTail: "```ts\nconst x = 1\nconst y = 2",
+    });
+  });
+
+  test("an open code fence with a trailing newline is still unstable until closed", () => {
+    const raw = "```ts\nconst x = 1\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "",
+      unstableTail: "```ts\nconst x = 1\n",
+    });
+  });
+
+  test("a closed fence stabilizes the full code block", () => {
+    const raw = "```ts\nconst x = 1\n```\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "```ts\nconst x = 1\n```",
+      unstableTail: "",
+    });
+  });
+
+  test("content after a closed fence stabilizes once its line is complete", () => {
+    const raw = "```ts\nfoo\n```\nAfter fence\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "```ts\nfoo\n```\nAfter fence",
+      unstableTail: "",
+    });
+  });
+
+  test("a second open fence pins the new fenced segment to the tail", () => {
+    const raw = "```ts\nfoo\n```\nGap\n```py\nbar";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "```ts\nfoo\n```\nGap",
+      unstableTail: "```py\nbar",
+    });
+  });
+
+  test("indented fence markers still toggle fence state", () => {
+    const raw = "  ```ts\nfoo\n  ```\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "  ```ts\nfoo\n  ```",
+      unstableTail: "",
+    });
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  3. headings, lists, tables — line-completeness rules                     */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe("stabilizeMarkdownPreview — markdown elements", () => {
+  test("a partial heading line stays in the unstable tail", () => {
+    expect(stabilizeMarkdownPreview("# Headi")).toEqual({
+      stableMarkdown: "",
+      unstableTail: "# Headi",
+    });
+  });
+
+  test("a complete heading line stabilizes after the newline", () => {
+    expect(stabilizeMarkdownPreview("# Heading\n")).toEqual({
+      stableMarkdown: "# Heading",
+      unstableTail: "",
+    });
+  });
+
+  test("partial list item stays in the unstable tail", () => {
+    const raw = "- one\n- two\n- thr";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "- one\n- two",
+      unstableTail: "- thr",
+    });
+  });
+
+  test("ordered list items stabilize line by line", () => {
+    const raw = "1. alpha\n2. beta\n3. ga";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "1. alpha\n2. beta",
+      unstableTail: "3. ga",
+    });
+  });
+
+  test("partial table row stays in the unstable tail", () => {
+    const raw = "| col a | col b |\n| ----- | ----- |\n| 1 | ";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "| col a | col b |\n| ----- | ----- |",
+      unstableTail: "| 1 | ",
+    });
+  });
+
+  test("complete table row stabilizes once its line ends", () => {
+    const raw = "| col a | col b |\n| ----- | ----- |\n| 1 | 2 |\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "| col a | col b |\n| ----- | ----- |\n| 1 | 2 |",
+      unstableTail: "",
+    });
+  });
+
+  test("table row inside an open code fence stays in the tail even when the row is complete", () => {
+    const raw = "```\n| 1 | 2 |\n";
+    expect(stabilizeMarkdownPreview(raw)).toEqual({
+      stableMarkdown: "",
+      unstableTail: "```\n| 1 | 2 |\n",
+    });
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  4. monotonicity                                                          */
+/*                                                                            */
+/*  Already-stable content must never move back into the tail as more text  */
+/*  arrives. Verified by replaying a token-by-token stream.                  */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe("stabilizeMarkdownPreview — monotonic stable boundary", () => {
+  function streamPrefixes(final: string): string[] {
+    const out: string[] = [];
+    for (let i = 1; i <= final.length; i++) {
+      out.push(final.slice(0, i));
+    }
+    return out;
+  }
+
+  test("stable prefix never shrinks across a typical streaming sequence", () => {
+    const final = "# Title\n\nSome **bold** text.\n\n- one\n- two\n";
+    let prevStableLen = 0;
+    for (const prefix of streamPrefixes(final)) {
+      const { stableMarkdown } = stabilizeMarkdownPreview(prefix);
+      expect(stableMarkdown.length).toBeGreaterThanOrEqual(prevStableLen);
+      prevStableLen = stableMarkdown.length;
+    }
+  });
+
+  test("stable prefix never shrinks across a stream that contains a fenced code block", () => {
+    const final = "intro\n```ts\nconst x = 1\n```\nafter\n";
+    let prevStableLen = 0;
+    for (const prefix of streamPrefixes(final)) {
+      const { stableMarkdown } = stabilizeMarkdownPreview(prefix);
+      expect(stableMarkdown.length).toBeGreaterThanOrEqual(prevStableLen);
+      prevStableLen = stableMarkdown.length;
+    }
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  5. convergence                                                           */
+/*                                                                            */
+/*  The preview must lossless-reconstruct the input: stable + boundary-\n + */
+/*  tail equals the raw stream. This guarantees no character is dropped or  */
+/*  duplicated between preview and the final rendered message.              */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe("stabilizeMarkdownPreview — convergence", () => {
+  function recombine(raw: string): string {
+    const { stableMarkdown, unstableTail } = stabilizeMarkdownPreview(raw);
+    if (!stableMarkdown) return unstableTail;
+    if (!unstableTail) {
+      // The trailing newline that separated stable from tail was consumed when
+      // tail was sliced as []. Reattach it so we recover the original input.
+      return raw.endsWith("\n") ? `${stableMarkdown}\n` : stableMarkdown;
+    }
+    return `${stableMarkdown}\n${unstableTail}`;
+  }
+
+  const cases = [
+    "",
+    "Hello",
+    "Hello\n",
+    "First\nSecond\n",
+    "First\nSecond\nThird par",
+    "# Heading\n\nBody text.\n",
+    "intro\n```ts\nconst x = 1\n```\nafter\n",
+    "```ts\nconst x = 1\n",
+    "- one\n- two\n- thr",
+    "| a | b |\n| - | - |\n| 1 | 2 |\n",
+  ];
+
+  for (const raw of cases) {
+    test(`recombines: ${JSON.stringify(raw)}`, () => {
+      expect(recombine(raw)).toBe(raw);
+    });
+  }
+});

--- a/fe+convex/components/agent/streamingMarkdown.ts
+++ b/fe+convex/components/agent/streamingMarkdown.ts
@@ -5,17 +5,16 @@
  *
  *   - `stableMarkdown`: complete, newline-terminated content that lives outside
  *     any open fenced code block — safe to render through the full markdown
- *     pipeline.
+ *     pipeline. Each stabilized line includes its terminating "\n", so the
+ *     concatenation `stableMarkdown + unstableTail` is exactly equal to the
+ *     original input for every input.
  *   - `unstableTail`: the trailing partial line, plus everything inside any
  *     currently-open code fence. Rendered as plain text until more tokens
  *     arrive.
  *
  * Invariants:
- *   - `stableMarkdown + (stableMarkdown && unstableTail ? "\n" : "") + unstableTail`
- *     reconstructs the original text exactly when the stable portion is
- *     non-empty (because the newline that terminated the last stable line is
- *     consumed by the join boundary). When `stableMarkdown` is empty, the
- *     unstable tail equals the original input.
+ *   - `stableMarkdown + unstableTail === raw` for every input. The terminating
+ *     "\n" of each stable line lives at the end of `stableMarkdown`.
  *   - Already-stable content never moves back into the tail as more text
  *     arrives — the boundary advances monotonically.
  *   - A line only becomes stable once it is followed by a newline AND the
@@ -31,36 +30,62 @@ export function stabilizeMarkdownPreview(raw: string): {
   }
 
   const lines = raw.split("\n");
-  const endsWithNewline = raw.endsWith("\n");
 
-  // Lines [0..completeCount-1] are complete (followed by a "\n" in `raw`).
-  // The remaining slice — `lines[completeCount..]` joined by "\n" — is the
-  // trailing partial fragment (and is "" when raw ends with a newline).
-  const completeCount = endsWithNewline ? lines.length - 1 : lines.length - 1;
+  // The last entry from `split("\n")` is the trailing partial line — it has no
+  // "\n" after it in `raw`. Lines [0..completeCount-1] are complete (each is
+  // followed by "\n" in `raw`).
+  const completeCount = lines.length - 1;
 
-  // Walk the complete lines, tracking fence state. The last index where the
-  // fence is closed is the safe boundary; anything past it must stay in the
-  // tail because either the line is partial or we're still inside a fence.
+  // Walk the complete lines, tracking fence state per CommonMark rules:
+  //   - An opener is a line of up to 3 leading spaces/tabs, then 3+ backticks,
+  //     optionally followed by an info string.
+  //   - A closer must use the same character with at least as many backticks
+  //     as the opener AND have nothing but whitespace after the backticks.
+  //     A line like ```ts inside an open fence is therefore NOT a closer.
+  //
+  // The last index where the fence is closed is the safe boundary; anything
+  // past it must stay in the tail (either still partial or still fenced).
   let insideFence = false;
+  let openerLen = 0;
   let safeEnd = 0;
   for (let i = 0; i < completeCount; i++) {
-    if (isFenceLine(lines[i])) {
-      insideFence = !insideFence;
+    const line = lines[i];
+    if (!insideFence) {
+      const opener = matchFenceOpener(line);
+      if (opener !== null) {
+        insideFence = true;
+        openerLen = opener;
+      }
+    } else if (isFenceCloser(line, openerLen)) {
+      insideFence = false;
+      openerLen = 0;
     }
     if (!insideFence) {
       safeEnd = i + 1;
     }
   }
 
-  const stableLines = lines.slice(0, safeEnd);
-  const tailLines = lines.slice(safeEnd);
+  // Each stable line consumes a trailing "\n" in `raw`, so we attach one per
+  // stabilized line. The unstable tail is whatever's left, joined with "\n".
+  const stableMarkdown =
+    safeEnd > 0 ? lines.slice(0, safeEnd).join("\n") + "\n" : "";
+  const unstableTail = lines.slice(safeEnd).join("\n");
 
-  return {
-    stableMarkdown: stableLines.join("\n"),
-    unstableTail: tailLines.join("\n"),
-  };
+  return { stableMarkdown, unstableTail };
 }
 
-function isFenceLine(line: string): boolean {
-  return line.trimStart().startsWith("```");
+const FENCE_OPENER = /^[ \t]{0,3}(`{3,})/;
+const FENCE_CLOSER = /^[ \t]{0,3}(`{3,})[ \t]*$/;
+
+// Returns the opener fence length, or null if the line isn't an opener.
+function matchFenceOpener(line: string): number | null {
+  const m = FENCE_OPENER.exec(line);
+  return m ? m[1].length : null;
+}
+
+// A closer must match the opener char (always backtick here), use ≥ openerLen
+// backticks, and have nothing but optional whitespace after the run.
+function isFenceCloser(line: string, openerLen: number): boolean {
+  const m = FENCE_CLOSER.exec(line);
+  return !!m && m[1].length >= openerLen;
 }

--- a/fe+convex/components/agent/streamingMarkdown.ts
+++ b/fe+convex/components/agent/streamingMarkdown.ts
@@ -1,0 +1,66 @@
+/**
+ * Stable-prefix markdown preview helper for streaming assistant text.
+ *
+ * Splits an in-progress markdown stream into two pieces:
+ *
+ *   - `stableMarkdown`: complete, newline-terminated content that lives outside
+ *     any open fenced code block — safe to render through the full markdown
+ *     pipeline.
+ *   - `unstableTail`: the trailing partial line, plus everything inside any
+ *     currently-open code fence. Rendered as plain text until more tokens
+ *     arrive.
+ *
+ * Invariants:
+ *   - `stableMarkdown + (stableMarkdown && unstableTail ? "\n" : "") + unstableTail`
+ *     reconstructs the original text exactly when the stable portion is
+ *     non-empty (because the newline that terminated the last stable line is
+ *     consumed by the join boundary). When `stableMarkdown` is empty, the
+ *     unstable tail equals the original input.
+ *   - Already-stable content never moves back into the tail as more text
+ *     arrives — the boundary advances monotonically.
+ *   - A line only becomes stable once it is followed by a newline AND the
+ *     fence state is balanced through that line. Open code fences hold the
+ *     entire fenced segment in the tail until the closing fence arrives.
+ */
+export function stabilizeMarkdownPreview(raw: string): {
+  stableMarkdown: string;
+  unstableTail: string;
+} {
+  if (!raw) {
+    return { stableMarkdown: "", unstableTail: "" };
+  }
+
+  const lines = raw.split("\n");
+  const endsWithNewline = raw.endsWith("\n");
+
+  // Lines [0..completeCount-1] are complete (followed by a "\n" in `raw`).
+  // The remaining slice — `lines[completeCount..]` joined by "\n" — is the
+  // trailing partial fragment (and is "" when raw ends with a newline).
+  const completeCount = endsWithNewline ? lines.length - 1 : lines.length - 1;
+
+  // Walk the complete lines, tracking fence state. The last index where the
+  // fence is closed is the safe boundary; anything past it must stay in the
+  // tail because either the line is partial or we're still inside a fence.
+  let insideFence = false;
+  let safeEnd = 0;
+  for (let i = 0; i < completeCount; i++) {
+    if (isFenceLine(lines[i])) {
+      insideFence = !insideFence;
+    }
+    if (!insideFence) {
+      safeEnd = i + 1;
+    }
+  }
+
+  const stableLines = lines.slice(0, safeEnd);
+  const tailLines = lines.slice(safeEnd);
+
+  return {
+    stableMarkdown: stableLines.join("\n"),
+    unstableTail: tailLines.join("\n"),
+  };
+}
+
+function isFenceLine(line: string): boolean {
+  return line.trimStart().startsWith("```");
+}


### PR DESCRIPTION
## Summary

Streaming assistant messages now render with markdown formatting progressively as tokens arrive, instead of showing a raw text blob that flips into formatted markdown only when the run finishes. Implements #35.

## Approach

A new helper `stabilizeMarkdownPreview(raw)` splits in-progress text into:

- `stableMarkdown` — newline-terminated content that is outside any open code fence; safe to send through `RichAgentMarkdown`.
- `unstableTail` — the trailing partial line plus any currently-open fenced code block; rendered as plain text with the streaming cursor until more tokens arrive.

Conservative rules per the issue spec:

- Only complete (newline-terminated) lines can enter `stableMarkdown`.
- An open code fence pins the entire fenced segment to the tail until the closing fence arrives.
- Headings, list items, and table rows stabilize once their line ends.
- The boundary is monotonic: already-stable content never returns to the tail as more text arrives.

`MessageBubble.AssistantTextBlock` now renders `stableMarkdown` through `RichAgentMarkdown` and the `unstableTail` as plain text in a `whitespace-pre-wrap` span with the streaming cursor. Final, non-streaming messages still render through the regular markdown path, so when streaming ends the output converges to the same persisted markdown.

No runtime, persistence, or transport contracts changed — this is a render-only improvement.

## Files

- `fe+convex/components/agent/streamingMarkdown.ts` — new stable-prefix splitter
- `fe+convex/components/agent/streamingMarkdown.test.ts` — 29 unit tests
- `fe+convex/components/agent/MessageBubble.tsx` — uses the splitter on the streaming branch

## Test plan

- [x] `bun test components/agent/streamingMarkdown.test.ts` — 29/29 pass
- [x] `bun test components/` (full agent suite) — 98/98 pass
- [x] `bunx tsc --noEmit` — no new TypeScript errors on changed files
- [ ] Manual verification: long markdown-heavy assistant response renders incrementally without raw-blob flip

### Tests cover
- empty input, partial line, complete line
- open code fence pins entire segment to tail
- closed fence stabilizes whole code block
- partial heading / list item / table row stays in tail
- monotonicity: stable boundary never shrinks across token-by-token replay
- convergence: stable + tail recombines to the original input lossless

## Out of scope

- Runtime/transport changes
- New artifact types or question-card blocks
- Aggressive parsing of arbitrary partial markdown grammar beyond the conservative stable-prefix rules

Closes #35.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAH4p2BgBaJCXJ4mLwAyz2)_