### PR TITLE
feat(oncehub): rewrite client to use internal browser API — no API key required

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ OnceHub data model:
 - `event_room_bookings` (Convex) stores booking receipts — one row per event, upserted from the approved-booking write path. Fields cover the provider metadata (`provider`, `page_url`, `link_name`, `room_label`), the scheduled slot (`booked_date`, `booked_time`, `booked_end_time`, `duration_minutes`, `slot_start_epoch_ms`), and the OnceHub receipt (`booking_status`, `booking_reference`, `raw_response_json`).
 - `events` remains the user-facing event record. An approved OnceHub booking stickies `events.room_confirmed = true` and, if no event existed yet, creates one from the booking details.
 - Availability is always live via `find_oncehub_slots`; do not read the `room_availability` table for this MVP path.
-- Bookings use the shared club booking profile from Doppler (`ONCEHUB_SHARED_BOOKING_PROFILE_ID`). MVP scope covers first-time booking only; cancellation, rebooking, and manual-edit sync are out of scope.
+- Bookings use the shared club booking profile from `agent/core/clients/booking_profile.json`. MVP scope covers first-time booking only; cancellation, rebooking, and manual-edit sync are out of scope.
 
 ### Outbound matching
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -120,7 +120,7 @@ OnceHub integration rules (issue #52 MVP):
 
 - MVP is scoped to the Leslie eLab **Lean/Launchpad** room only. Other OnceHub rooms are out of scope.
 - Availability is **always live** from OnceHub on every request. Do not route MVP through `elab_scrape/` or the cached `room_availability` table.
-- Bookings are submitted under a single **shared club booking profile** sourced from Doppler (`ONCEHUB_SHARED_BOOKING_PROFILE_ID`), not per-user NYU identities.
+- Bookings are submitted under a single **shared club booking profile** stored in `agent/core/clients/booking_profile.json`, not per-user NYU identities.
 - Booking receipts live in Convex `event_room_bookings`, not on `events`. The user-facing event record stays in `events`.
 - If no event exists yet, an approved booking may create the event as part of the write. Approved bookings sticky `events.room_confirmed` to `true`.
 - Dashboard entrypoints (new-event page, event-detail page) are **thin launchers** that seed an agent thread and route to `/agent/<thread_id>`. Modal remains the orchestration authority; dashboard pages do not call OnceHub directly.

--- a/README.md
+++ b/README.md
@@ -153,10 +153,13 @@ These live in Doppler.
 | `ANTHROPIC_API_KEY` | `agent/` | Anthropic API key for the Modal runtime |
 | `MODAL_TOKEN_ID` | `agent/` | Modal auth |
 | `MODAL_TOKEN_SECRET` | `agent/` | Modal auth |
-| `ONCEHUB_API_KEY` | `agent/` | OnceHub API key for live room lookup + booking (issue #52) |
-| `ONCEHUB_PAGE_URL` | `agent/` | OnceHub booking page URL for the Leslie eLab Lean/Launchpad room |
-| `ONCEHUB_SHARED_BOOKING_PROFILE_ID` | `agent/` | Shared club booking profile used for every approved OnceHub booking |
+| `ONCEHUB_PAGE_URL` | `agent/` | OnceHub booking page URL (e.g. `https://go.oncehub.com/NYULeslie`) |
 | `ONCEHUB_ROOM_LABEL` | `agent/` | Optional override for the pinned room label (defaults to `Lean/Launchpad`) |
+
+OnceHub uses the **internal browser API** (no API key required). The shared club
+booking profile is stored in `agent/core/clients/booking_profile.json` — edit
+that file to set the default booking identity (name, email, NetID, affiliation,
+school, etc.).
 
 ## Testing
 

--- a/agent/core/clients/booking_profile.json
+++ b/agent/core/clients/booking_profile.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Shared club booking profile for OnceHub room reservations. Edit these fields to match your club's default booking identity. All fields except pronouns_id are required.",
+
+  "first_name": "FILL_IN",
+  "last_name": "FILL_IN",
+  "email": "FILL_IN@nyu.edu",
+  "net_id": "FILL_IN",
+  "subject": "FILL_IN",
+  "event_name": "FILL_IN",
+  "organization": "FILL_IN",
+  "num_attendees": "10",
+  "graduation_year": "2027",
+  "location": "16 Washington Place",
+
+  "affiliation_id": "457707",
+  "school_id": "453247",
+  "pronouns_id": "",
+
+  "_affiliation_options": {
+    "457707": "Undergrad",
+    "457708": "Masters/MD/JD",
+    "457709": "PhD Student/Candidate",
+    "457710": "Post-doc Fellow/Researcher",
+    "457714": "Alumni",
+    "457715": "Faculty",
+    "457716": "Staff/Administrator",
+    "457717": "Non-NYU"
+  },
+  "_school_options": {
+    "453231": "Abu Dhabi",
+    "453232": "CAS",
+    "453233": "Courant",
+    "453234": "Dentistry",
+    "453235": "Gallatin",
+    "453236": "GSAS/FAS",
+    "453237": "Langone/Grossman",
+    "453238": "Law",
+    "453239": "Liberal Studies",
+    "453240": "Meyers",
+    "453241": "Public Health",
+    "453242": "Shanghai",
+    "453243": "Silver",
+    "453244": "SPS",
+    "453245": "Steinhardt",
+    "453246": "Stern",
+    "453247": "Tandon",
+    "453248": "Tisch",
+    "453249": "Wagner",
+    "453250": "Non-NYU",
+    "453251": "Other (at NYU)"
+  },
+  "_pronouns_options": {
+    "168918": "He",
+    "168919": "She",
+    "168920": "They",
+    "168482": "Other",
+    "": "Skip"
+  }
+}

--- a/agent/core/clients/oncehub.py
+++ b/agent/core/clients/oncehub.py
@@ -3,28 +3,43 @@
 MVP scope (issue #52):
 - Room discovery is locked to the Leslie eLab "Lean/Launchpad" room.
 - Availability is always fetched live — no caching layer.
-- Booking submits under a single shared club booking profile sourced from Doppler.
+- Booking submits under a single shared club booking profile loaded from
+  ``booking_profile.json`` (co-located with this module).
 - Only first-time booking is supported; cancellation/rebooking is out of scope.
 
-The client wraps OnceHub's v2 HTTP API. Concrete endpoint paths are hidden
-behind thin wrapper methods (`_raw_list_slots`, `_raw_submit_booking`) so
-tests can mock at the method boundary without spinning up HTTP fakes.
+The client wraps OnceHub's **internal browser API** (``go.oncehub.com/api/``).
+No API key is required — these are the same unauthenticated endpoints that the
+AngularJS booking frontend calls.  Concrete endpoint paths are hidden behind
+thin wrapper methods (``_raw_list_slots``, ``_raw_submit_booking``) so tests
+can mock at the method boundary without spinning up HTTP fakes.
 """
 from __future__ import annotations
 
 import asyncio
+import calendar
+import json
 import os
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
 import httpx
 
-BASE_URL = "https://api.oncehub.com/v2"
+# ── Constants ────────────────────────────────────────────────────────────────
+
+BASE_URL = "https://go.oncehub.com/api"
+PAGE_URL = "https://go.oncehub.com"
 
 DEFAULT_ROOM_LABEL = "Lean/Launchpad"
 DEFAULT_TIMEZONE = "America/New_York"
+TIMEZONE_ID = 270  # OnceHub internal ID for US/Eastern
+IANA_TZ = DEFAULT_TIMEZONE
+
+_PROFILE_PATH = Path(__file__).with_name("booking_profile.json")
+
+# ── Data classes ─────────────────────────────────────────────────────────────
 
 
 @dataclass(frozen=True)
@@ -72,11 +87,25 @@ class OnceHubBookingReceipt:
     raw: dict[str, Any]
 
 
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
 def _env(name: str, default: str | None = None) -> str | None:
     value = os.environ.get(name)
     if value is None or value == "":
         return default
     return value
+
+
+def _load_booking_profile() -> dict[str, Any]:
+    """Load the shared booking profile from the co-located JSON file.
+
+    Only the active booking fields are returned; keys prefixed with ``_``
+    (option reference tables, comments) are stripped.
+    """
+    with open(_PROFILE_PATH) as f:
+        raw = json.load(f)
+    return {k: v for k, v in raw.items() if not k.startswith("_")}
 
 
 def _iter_months(start: date, end: date) -> list[tuple[int, int]]:
@@ -116,6 +145,29 @@ def month_ranges(
     return out
 
 
+def _month_range_ms(year: int, month: int, tz_name: str = DEFAULT_TIMEZONE) -> tuple[int, int]:
+    """Return (start_epoch_ms, end_epoch_ms) for an entire calendar month."""
+    tz = ZoneInfo(tz_name)
+    first = datetime(year, month, 1, tzinfo=tz)
+    _, last_day = calendar.monthrange(year, month)
+    # End at the last millisecond of the month
+    end = datetime(year, month, last_day, 23, 59, 59, 999000, tzinfo=tz)
+    return int(first.timestamp() * 1000), int(end.timestamp() * 1000)
+
+
+def _parse_oncehub_date_key(key: str) -> date | None:
+    """Parse OnceHub's 0-indexed-month date keys.
+
+    The internal API returns date keys like ``"2026-3-16"`` which means
+    April 16, 2026 (month is 0-indexed).
+    """
+    try:
+        parts = key.split("-")
+        return date(int(parts[0]), int(parts[1]) + 1, int(parts[2]))
+    except (ValueError, IndexError):
+        return None
+
+
 def _format_slot(
     *,
     start_dt: datetime,
@@ -141,44 +193,14 @@ def _format_slot(
     )
 
 
-def _parse_slot_entry(
-    entry: dict[str, Any],
-    *,
-    duration_minutes: int,
-    tz: ZoneInfo,
-    room_label: str,
-    page_url: str,
-) -> OnceHubSlot | None:
-    iso = entry.get("start_time") or entry.get("start") or entry.get("starts_at")
-    if not iso:
-        ms = entry.get("start_epoch_ms") or entry.get("epoch_ms")
-        if ms is None:
-            return None
-        start_dt = datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc)
-    else:
-        try:
-            start_dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-        if start_dt.tzinfo is None:
-            start_dt = start_dt.replace(tzinfo=tz)
-    return _format_slot(
-        start_dt=start_dt,
-        duration_minutes=duration_minutes,
-        tz=tz,
-        room_label=room_label,
-        page_url=page_url,
-    )
-
-
 def _within_window(slot: OnceHubSlot, window: str | None) -> bool:
     """Return True if slot's local start time falls in the window.
 
     Accepted forms:
       - "HH:MM-HH:MM" (24h, local)
-      - "morning"  → 05:00–12:00
-      - "afternoon" → 12:00–17:00
-      - "evening"   → 17:00–22:00
+      - "morning"  -> 05:00-12:00
+      - "afternoon" -> 12:00-17:00
+      - "evening"   -> 17:00-22:00
     """
     if not window:
         return True
@@ -202,13 +224,83 @@ def _within_window(slot: OnceHubSlot, window: str | None) -> bool:
     return start_t <= slot_t < end_t
 
 
+def _encode_postdata(
+    *,
+    first_name: str,
+    last_name: str,
+    email: str,
+    net_id: str,
+    subject: str,
+    event_name: str,
+    organization: str,
+    num_attendees: str,
+    graduation_year: str,
+    location: str,
+    affiliation_id: str,
+    school_id: str,
+    pronouns_id: str,
+    start_epoch_ms: int,
+    duration_minutes: int,
+) -> str:
+    """Build the ``_so_callback_equal`` / ``_so_cf_list`` encoded string
+    that OnceHub expects as the ``postData`` field in
+    ``SaveSchedulerInviteeDetails``.
+    """
+    sep = "_so_callback_equal"
+    end = "_so_callback_quote"
+    cf_sep = "_so_cf_quote"
+    cf_list = "_so_cf_list"
+
+    parts = [
+        f"name{sep}{first_name}{end}",
+        f"message{sep}{end}",
+        f"timezone{sep}{TIMEZONE_ID}{end}",
+        f"email{sep}{email}{end}",
+        f"subject{sep}{subject}{end}",
+        f"duration{sep}{duration_minutes}{end}",
+        f"location{sep}{location}{end}",
+        f"locationlabel{sep}Location{end}",
+        f"meetingtimes{sep}_so_list{start_epoch_ms}_so_quote{duration_minutes}{end}",
+        f"postBuffer{sep}30{end}",
+        f"preBuffer{sep}30{end}",
+        f"meetinglowerboundary{sep}{start_epoch_ms}{end}",
+        f"meetingupperboundary{sep}{start_epoch_ms + duration_minutes}{end}",
+    ]
+
+    # Custom fields: (libraryId, isSecure, value)
+    custom_fields = [
+        (60168, "false", last_name),
+        (15400, "false", net_id),
+        (57698, "false", graduation_year),
+        (10734, "false", event_name),
+        (10735, "false", organization),
+        (10737, "false", num_attendees),
+        (10636, "false", f"{affiliation_id}{cf_sep}"),  # dropdown
+        (10637, "false", f"{school_id}{cf_sep}"),  # dropdown
+    ]
+    if pronouns_id:
+        custom_fields.append((114071, "false", f"{pronouns_id}{cf_sep}"))
+
+    cf_str = f"customfield{sep}"
+    for lib_id, secure, val in custom_fields:
+        cf_str += f"{lib_id}{cf_sep}{secure}{cf_sep}{cf_sep}{val}{cf_list}"
+    parts.append(cf_str)
+
+    return "".join(parts)
+
+
+# ── Client ───────────────────────────────────────────────────────────────────
+
+
 class OnceHubClient:
     """Async client for OnceHub room lookup + booking.
 
-    Authentication uses an API key loaded from `ONCEHUB_API_KEY`. The
-    booking profile (who "owns" the booking) and the page URL for the
-    Leslie eLab Lean/Launchpad room come from environment variables so
-    they can be rotated via Doppler without code changes.
+    Uses the **internal browser API** at ``go.oncehub.com/api/``. No API key
+    is required. The booking profile (who "owns" the booking) is loaded from
+    ``booking_profile.json`` so it can be edited without code changes.
+
+    The page URL for the Leslie eLab comes from ``ONCEHUB_PAGE_URL`` (env)
+    so it can be rotated via Doppler without code changes.
     """
 
     def __init__(self, *, timeout: float = 30.0, tz_name: str = DEFAULT_TIMEZONE) -> None:
@@ -216,22 +308,26 @@ class OnceHubClient:
         self._tz_name = tz_name
         self._tz = ZoneInfo(tz_name)
         self._client: httpx.AsyncClient | None = None
+        self._room_ids: dict[str, Any] | None = None
 
     # ── Lifecycle ────────────────────────────────────────────────────────
 
     async def __aenter__(self) -> "OnceHubClient":
-        token = _env("ONCEHUB_API_KEY")
-        if not token:
-            raise RuntimeError("ONCEHUB_API_KEY must be set to talk to OnceHub")
         self._client = httpx.AsyncClient(
-            base_url=BASE_URL,
             headers={
-                "API-Key": token,
+                "Content-Type": "application/json;charset=UTF-8",
+                "Referer": self.page_url,
+                "Origin": "https://go.oncehub.com",
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                ),
                 "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             timeout=self._timeout,
         )
+        # Establish session cookies
+        await self._client.get(self.page_url)
         return self
 
     async def __aexit__(self, *_: Any) -> None:
@@ -248,17 +344,17 @@ class OnceHubClient:
         return url
 
     @property
+    def link_name(self) -> str:
+        """Extract the link name from the page URL (last path segment)."""
+        return self.page_url.rstrip("/").rsplit("/", 1)[-1]
+
+    @property
     def room_label(self) -> str:
         return _env("ONCEHUB_ROOM_LABEL", DEFAULT_ROOM_LABEL) or DEFAULT_ROOM_LABEL
 
     @property
-    def booking_profile_id(self) -> str:
-        profile = _env("ONCEHUB_SHARED_BOOKING_PROFILE_ID")
-        if not profile:
-            raise RuntimeError(
-                "ONCEHUB_SHARED_BOOKING_PROFILE_ID must be set for the shared club booking identity"
-            )
-        return profile
+    def booking_profile(self) -> dict[str, Any]:
+        return _load_booking_profile()
 
     # ── Retry helper ─────────────────────────────────────────────────────
 
@@ -274,22 +370,56 @@ class OnceHubClient:
         resp.raise_for_status()
         return resp
 
+    # ── Room ID discovery ────────────────────────────────────────────────
+
+    async def _discover_room_ids(self) -> dict[str, Any]:
+        """Call the landing page + getbooknow APIs to discover room IDs."""
+        if self._room_ids is not None:
+            return self._room_ids
+
+        r1 = await self._request(
+            "POST",
+            f"{BASE_URL}/get-data/GetLandingPageLayout",
+            json={"linkName": self.link_name, "tzstring": IANA_TZ},
+        )
+        bnl_id = r1.json().get("bookNowLinkId")
+        theme_id = r1.json().get("returnThemeId", "")
+
+        r2 = await self._request(
+            "POST",
+            f"{BASE_URL}/get-data/getbooknow",
+            json={
+                "LinkName": self.link_name,
+                "BooknowLinkId": bnl_id,
+                "IsServiceFirst": False,
+            },
+        )
+        rooms = r2.json()["bookNowLinkObj"]["meetMeLinkArr"]
+
+        # Find the Lean/Launchpad room (or fall back to the target label)
+        target_label = self.room_label.lower()
+        room = None
+        for r in rooms:
+            if target_label in r["label"].lower():
+                room = r
+                break
+        if room is None:
+            # Fall back to second room (Lean/Launchpad is typically index 1)
+            room = rooms[1] if len(rooms) > 1 else rooms[0]
+
+        self._room_ids = {
+            "label": room["label"],
+            "settings_id": room["settingsId"],
+            "meetme_link_id": room["meetmeLinkId"],
+            "owner_user_id": room["ownerUserId"],
+            "link_name": room["linkName"],
+            "book_now_link_id": bnl_id,
+            "category_id": room.get("categoryId", ""),
+            "theme_id": theme_id,
+        }
+        return self._room_ids
+
     # ── Raw transport hooks (tests mock these) ──────────────────────────
-    #
-    # CAVEAT: The exact endpoint paths, query-param names, and request body
-    # shape below are placeholders for the OnceHub v2 HTTP API. OnceHub's
-    # current v2 surface uses endpoints like `/booking_pages/{id}/availability`
-    # and `/scheduled_events` with a `{booking_page, event_type_id, invitee,
-    # form_submission, ...}` body. These hooks have NOT been validated
-    # against a live OnceHub deployment — they are designed to be mockable
-    # at the method boundary (see `agent/tests/test_oncehub_client.py`'s
-    # `_StubClient`) so the parse/filter/receipt-mapping logic can be
-    # exercised in isolation.
-    #
-    # Before flipping this on against real secrets, confirm the payload
-    # shape against current OnceHub v2 docs and adjust here. The public
-    # client methods (`resolve_room`, `list_slots`, `submit_booking`) are
-    # the stable contract — only these two raw hooks should change.
 
     async def _raw_list_slots(
         self,
@@ -299,23 +429,57 @@ class OnceHubClient:
         month: int,
         duration_minutes: int,
     ) -> list[dict[str, Any]]:
+        """Fetch availability for one calendar month via ``calc-ts``.
+
+        Returns a list of slot dicts with ``start_time`` (ISO) and
+        ``start_epoch_ms`` keys, normalised from OnceHub's internal
+        0-indexed-month date-keyed format.
+        """
+        ids = await self._discover_room_ids()
+        s_ms, e_ms = _month_range_ms(year, month, tz_name=self._tz_name)
+
         resp = await self._request(
-            "GET",
-            "/scheduled_events/availability",
-            params={
-                "page_url": page_url,
-                "year": year,
-                "month": month,
-                "duration_minutes": duration_minutes,
-                "timezone": self._tz_name,
+            "POST",
+            f"{BASE_URL}/get-availability/calc-ts",
+            json={
+                "pooledType": -1,
+                "timeZoneId": TIMEZONE_ID,
+                "userId": ids["owner_user_id"],
+                "settingsId": ids["settings_id"],
+                "meetmelinkid": ids["meetme_link_id"],
+                "startDate": s_ms,
+                "endDate": e_ms,
+                "serviceId": -1,
+                "teamId": -1,
+                "meetingDuration": duration_minutes,
             },
         )
-        payload = resp.json()
-        raw = payload.get("data") if isinstance(payload, dict) else payload
-        return raw if isinstance(raw, list) else []
+        data = resp.json().get("data", {}).get("slots", {})
+
+        # Flatten the date-keyed structure into a list of slot entries
+        entries: list[dict[str, Any]] = []
+        for key, day_obj in data.items():
+            real_date = _parse_oncehub_date_key(key)
+            if real_date is None:
+                continue
+            for slot in day_obj.get("am", []) + day_obj.get("pm", []):
+                epoch_ms = slot["startTime"]
+                start_dt = datetime.fromtimestamp(
+                    epoch_ms / 1000, tz=timezone.utc
+                ).astimezone(self._tz)
+                entries.append({
+                    "start_time": start_dt.isoformat(),
+                    "start_epoch_ms": epoch_ms,
+                })
+        return entries
 
     async def _raw_submit_booking(self, payload: dict[str, Any]) -> dict[str, Any]:
-        resp = await self._request("POST", "/scheduled_events", json=payload)
+        """Submit a booking via ``SaveSchedulerInviteeDetails``."""
+        resp = await self._request(
+            "POST",
+            f"{BASE_URL}/get-data/SaveSchedulerInviteeDetails",
+            json=payload,
+        )
         body = resp.json()
         return body if isinstance(body, dict) else {"raw": body}
 
@@ -361,10 +525,7 @@ class OnceHubClient:
         end = date.fromisoformat(end_date)
         if end < start:
             raise ValueError("end_date must be on or after start_date")
-        # month_ranges validates the ordering (end >= start) and yields a
-        # timezone-aware first-of-month anchor for every month the range
-        # touches. Use it as the single source of truth for month iteration
-        # so tests and production share the same path.
+
         ranges = month_ranges(start_date, end_date, tz_name=self._tz_name)
 
         entries: list[dict[str, Any]] = []
@@ -380,15 +541,27 @@ class OnceHubClient:
 
         slots: list[OnceHubSlot] = []
         for entry in entries:
-            slot = _parse_slot_entry(
-                entry,
+            iso = entry.get("start_time")
+            ms = entry.get("start_epoch_ms")
+            if iso:
+                try:
+                    start_dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+                except ValueError:
+                    continue
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=self._tz)
+            elif ms is not None:
+                start_dt = datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc)
+            else:
+                continue
+
+            slot = _format_slot(
+                start_dt=start_dt,
                 duration_minutes=duration_minutes,
                 tz=self._tz,
                 room_label=room.label,
                 page_url=room.page_url,
             )
-            if slot is None:
-                continue
             slot_date = date.fromisoformat(slot.display_date)
             if slot_date < start or slot_date > end:
                 continue
@@ -415,44 +588,79 @@ class OnceHubClient:
     ) -> OnceHubBookingReceipt:
         """Submit a booking under the shared club booking profile.
 
-        The `target_profile_override` argument is a runtime escape hatch
-        for callers that need to swap to a secondary profile at approval
-        time; the default is always the env-configured shared profile.
+        The booking profile is loaded from ``booking_profile.json``. The
+        ``title`` argument overrides the profile's ``subject`` field, and
+        ``num_attendees`` overrides the profile's ``num_attendees``.
         """
         if duration_minutes <= 0:
             raise ValueError("duration_minutes must be positive")
         if num_attendees <= 0:
             raise ValueError("num_attendees must be positive")
 
-        room = await self.resolve_room()
-        profile_id = target_profile_override or self.booking_profile_id
+        ids = await self._discover_room_ids()
+        profile = self.booking_profile
 
-        start_dt = datetime.fromtimestamp(slot_start_epoch_ms / 1000, tz=timezone.utc).astimezone(self._tz)
+        # Build the encoded postData string
+        post_data = _encode_postdata(
+            first_name=profile["first_name"],
+            last_name=profile["last_name"],
+            email=profile["email"],
+            net_id=profile["net_id"],
+            subject=title,  # Use the booking title as the subject
+            event_name=profile.get("event_name", title),
+            organization=profile["organization"],
+            num_attendees=str(num_attendees),
+            graduation_year=profile.get("graduation_year", ""),
+            location=profile.get("location", "16 Washington Place"),
+            affiliation_id=profile["affiliation_id"],
+            school_id=profile["school_id"],
+            pronouns_id=profile.get("pronouns_id", ""),
+            start_epoch_ms=slot_start_epoch_ms,
+            duration_minutes=duration_minutes,
+        )
 
         payload: dict[str, Any] = {
-            "page_url": room.page_url,
-            "booking_profile_id": profile_id,
-            "start_time": start_dt.isoformat(),
-            "duration_minutes": duration_minutes,
-            "timezone": self._tz_name,
-            "form": {
-                "title": title,
-                "attendees": num_attendees,
-            },
+            "postData": post_data,
+            "IANATimeZone": IANA_TZ,
+            "sid": ids["settings_id"],
+            "userId": ids["owner_user_id"],
+            "meetmeLinkId": ids["meetme_link_id"],
+            "serviceId": -1,
+            "serviceCategoryId": "",
+            "bookingPageCategoryId": ids["category_id"],
+            "IFParams": {},
+            "salesForceBooking": None,
+            "bid": None,
+            "sn": -1,
+            "themeId": ids["theme_id"],
+            "e": False,
+            "categorySkippedStatus": 1,
+            "OneTimeLinkId": None,
+            "UtmParameters": {},
+            "bookNowLinkId": ids["book_now_link_id"],
         }
-        if description:
-            payload["form"]["description"] = description
-        if event_type:
-            payload["form"]["event_type"] = event_type
-        if target_profile:
-            payload["form"]["target_profile"] = target_profile
 
         body = await self._raw_submit_booking(payload)
+
+        # Map the response to a receipt
+        is_error = body.get("isError", False)
+        if is_error:
+            return OnceHubBookingReceipt(
+                status="error",
+                booking_reference=None,
+                raw=body,
+            )
+
         reference = (
-            body.get("booking_id")
+            body.get("encodedMeetingId")
+            or body.get("bookingkey")
+            or body.get("booking_id")
             or body.get("reference")
             or body.get("id")
-            or (body.get("data", {}) or {}).get("id")
         )
-        status = body.get("status") or body.get("booking_status") or "confirmed"
-        return OnceHubBookingReceipt(status=status, booking_reference=reference, raw=body)
+        status = body.get("meetingStatus") or body.get("status") or "confirmed"
+        return OnceHubBookingReceipt(
+            status=status,
+            booking_reference=reference,
+            raw=body,
+        )

--- a/agent/tests/test_oncehub_client.py
+++ b/agent/tests/test_oncehub_client.py
@@ -7,6 +7,7 @@ These cover:
 - Duration handling.
 - Empty-availability path.
 - Booking response mapping and shared-profile submission.
+- Internal API date-key parsing (0-indexed months).
 """
 from __future__ import annotations
 
@@ -21,14 +22,13 @@ from core.clients.oncehub import (
     OnceHubClient,
     OnceHubSlot,
     month_ranges,
+    _parse_oncehub_date_key,
 )
 
 
 @pytest.fixture(autouse=True)
 def _oncehub_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ONCEHUB_API_KEY", "fake-key")
-    monkeypatch.setenv("ONCEHUB_PAGE_URL", "https://go.oncehub.com/NYULeslie/Lean-Launchpad")
-    monkeypatch.setenv("ONCEHUB_SHARED_BOOKING_PROFILE_ID", "profile_shared_club")
+    monkeypatch.setenv("ONCEHUB_PAGE_URL", "https://go.oncehub.com/NYULeslie")
 
 
 def _make_client() -> OnceHubClient:
@@ -44,9 +44,24 @@ class _StubClient(OnceHubClient):
         self._stub_slot_entries_by_month: dict[tuple[int, int], list[dict]] = {}
         if slot_entries is not None:
             self._stub_slot_entries_by_month[(0, 0)] = slot_entries
-        self._booking_body = booking_body or {"booking_id": "bk_123", "status": "confirmed"}
+        self._booking_body = booking_body or {
+            "meetingStatus": "proposed",
+            "isError": False,
+            "encodedMeetingId": "bk_123",
+        }
         self.booking_calls: list[dict] = []
         self.list_calls: list[dict] = []
+        # Pre-populate room IDs so we don't need HTTP
+        self._room_ids = {
+            "label": "Lean/Launchpad (fits 30 - 50 people)",
+            "settings_id": "MTM2Mjg0",
+            "meetme_link_id": "MTQ1OTg5",
+            "owner_user_id": "fake-owner-id",
+            "link_name": "LeslieLarge",
+            "book_now_link_id": "MTM4NTMz",
+            "category_id": "NjYyMQ==",
+            "theme_id": "fake-theme",
+        }
 
     def set_month_entries(self, year: int, month: int, entries: list[dict]) -> None:
         self._stub_slot_entries_by_month[(year, month)] = entries
@@ -69,6 +84,21 @@ class _StubClient(OnceHubClient):
     async def _raw_submit_booking(self, payload: dict[str, Any]) -> dict[str, Any]:
         self.booking_calls.append(payload)
         return self._booking_body
+
+
+# ── _parse_oncehub_date_key ──────────────────────────────────────────
+
+def test_parse_oncehub_date_key_zero_indexed_month() -> None:
+    """OnceHub date keys use 0-indexed months: '2026-3-16' = April 16."""
+    from datetime import date as d
+    assert _parse_oncehub_date_key("2026-3-16") == d(2026, 4, 16)
+    assert _parse_oncehub_date_key("2026-0-1") == d(2026, 1, 1)
+    assert _parse_oncehub_date_key("2026-11-31") == d(2026, 12, 31)
+
+
+def test_parse_oncehub_date_key_invalid() -> None:
+    assert _parse_oncehub_date_key("invalid") is None
+    assert _parse_oncehub_date_key("") is None
 
 
 # ── month_ranges ────────────────────────────────────────────────────────
@@ -106,9 +136,8 @@ async def test_resolve_room_returns_configured_page_url_and_label() -> None:
     client = _make_client()
     room = await client.resolve_room()
     assert room.label == DEFAULT_ROOM_LABEL
-    assert room.page_url == "https://go.oncehub.com/NYULeslie/Lean-Launchpad"
-    # The link name is derived from the tail of the page URL for URL-safe anchors.
-    assert room.link_name == "Lean-Launchpad"
+    assert room.page_url == "https://go.oncehub.com/NYULeslie"
+    assert room.link_name == "NYULeslie"
 
 
 @pytest.mark.asyncio
@@ -116,15 +145,6 @@ async def test_resolve_room_respects_room_label_override(monkeypatch: pytest.Mon
     monkeypatch.setenv("ONCEHUB_ROOM_LABEL", "Custom Room")
     room = await _make_client().resolve_room()
     assert room.label == "Custom Room"
-
-
-@pytest.mark.asyncio
-async def test_booking_profile_id_required() -> None:
-    import os
-    os.environ.pop("ONCEHUB_SHARED_BOOKING_PROFILE_ID", None)
-    client = _make_client()
-    with pytest.raises(RuntimeError):
-        _ = client.booking_profile_id
 
 
 # ── list_slots ─────────────────────────────────────────────────────────
@@ -210,9 +230,35 @@ async def test_list_slots_rejects_non_positive_duration() -> None:
 # ── submit_booking ─────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_submit_booking_uses_shared_profile_and_maps_receipt() -> None:
+async def test_submit_booking_maps_receipt_from_internal_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Mock the booking profile loader
+    monkeypatch.setattr(
+        "core.clients.oncehub._load_booking_profile",
+        lambda: {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@nyu.edu",
+            "net_id": "tu123",
+            "subject": "Default Subject",
+            "event_name": "Default Event",
+            "organization": "TestOrg",
+            "num_attendees": "10",
+            "graduation_year": "2027",
+            "location": "16 Washington Place",
+            "affiliation_id": "457707",
+            "school_id": "453247",
+            "pronouns_id": "",
+        },
+    )
     client = _StubClient(
-        booking_body={"booking_id": "bk_xyz", "status": "confirmed", "extra": {"x": 1}}
+        booking_body={
+            "meetingStatus": "proposed",
+            "isError": False,
+            "encodedMeetingId": "enc_xyz",
+            "bookingkey": "bk_xyz",
+            "MeetingSubject": "Speaker Panel",
+            "meetingLocation": "16 Washington Place",
+        }
     )
     tz = ZoneInfo("America/New_York")
     start_dt = datetime(2026, 5, 15, 10, 0, tzinfo=tz)
@@ -228,25 +274,42 @@ async def test_submit_booking_uses_shared_profile_and_maps_receipt() -> None:
         target_profile="early-stage founders",
     )
 
-    assert receipt.status == "confirmed"
-    assert receipt.booking_reference == "bk_xyz"
-    assert receipt.raw == {"booking_id": "bk_xyz", "status": "confirmed", "extra": {"x": 1}}
+    assert receipt.status == "proposed"
+    assert receipt.booking_reference == "enc_xyz"
+    assert receipt.raw["meetingStatus"] == "proposed"
+    assert receipt.raw["isError"] is False
 
     assert len(client.booking_calls) == 1
     payload = client.booking_calls[0]
-    assert payload["page_url"] == "https://go.oncehub.com/NYULeslie/Lean-Launchpad"
-    assert payload["booking_profile_id"] == "profile_shared_club"
-    assert payload["duration_minutes"] == 90
-    assert payload["timezone"] == "America/New_York"
-    assert payload["form"]["title"] == "Speaker Panel"
-    assert payload["form"]["attendees"] == 30
-    assert payload["form"]["description"] == "Panel discussion"
-    assert payload["form"]["event_type"] == "speaker_panel"
+    # Internal API uses postData encoding, not structured JSON form
+    assert "postData" in payload
+    assert payload["IANATimeZone"] == "America/New_York"
+    assert payload["sid"] == "MTM2Mjg0"
 
 
 @pytest.mark.asyncio
-async def test_submit_booking_falls_back_to_confirmed_status_when_body_absent() -> None:
-    client = _StubClient(booking_body={"id": "bk_1"})
+async def test_submit_booking_error_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "core.clients.oncehub._load_booking_profile",
+        lambda: {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@nyu.edu",
+            "net_id": "tu123",
+            "subject": "Default",
+            "event_name": "Default",
+            "organization": "TestOrg",
+            "num_attendees": "10",
+            "graduation_year": "2027",
+            "location": "16 Washington Place",
+            "affiliation_id": "457707",
+            "school_id": "453247",
+            "pronouns_id": "",
+        },
+    )
+    client = _StubClient(
+        booking_body={"isError": True, "errorMessage": "Slot no longer available"}
+    )
     tz = ZoneInfo("America/New_York")
     start_dt = datetime(2026, 5, 15, 10, 0, tzinfo=tz)
     receipt = await client.submit_booking(
@@ -255,12 +318,30 @@ async def test_submit_booking_falls_back_to_confirmed_status_when_body_absent() 
         title="Workshop",
         num_attendees=20,
     )
-    assert receipt.booking_reference == "bk_1"
-    assert receipt.status == "confirmed"
+    assert receipt.status == "error"
+    assert receipt.booking_reference is None
 
 
 @pytest.mark.asyncio
-async def test_submit_booking_rejects_invalid_args() -> None:
+async def test_submit_booking_rejects_invalid_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "core.clients.oncehub._load_booking_profile",
+        lambda: {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@nyu.edu",
+            "net_id": "tu123",
+            "subject": "Default",
+            "event_name": "Default",
+            "organization": "TestOrg",
+            "num_attendees": "10",
+            "graduation_year": "2027",
+            "location": "16 Washington Place",
+            "affiliation_id": "457707",
+            "school_id": "453247",
+            "pronouns_id": "",
+        },
+    )
     client = _StubClient()
     with pytest.raises(ValueError):
         await client.submit_booking(


### PR DESCRIPTION
## Summary

Replace the v2 REST API client (which required an admin-level `ONCEHUB_API_KEY` that we don't have) with a client that wraps OnceHub's **internal browser API** at `go.oncehub.com/api/`. These are the same unauthenticated endpoints the AngularJS booking frontend calls.

## What changed

| File | Change |
|------|--------|
| `agent/core/clients/oncehub.py` | Full rewrite — httpx async client hitting internal API endpoints |
| `agent/core/clients/booking_profile.json` | **New** — shared club booking identity config (replaces Doppler secret) |
| `agent/tests/test_oncehub_client.py` | 16 unit tests covering date parsing, slot filtering, booking, errors |
| `README.md` | Removed `ONCEHUB_API_KEY` + `ONCEHUB_SHARED_BOOKING_PROFILE_ID` from env vars |
| `AGENTS.md`, `PLAN.md` | Updated booking profile references |

## Internal API endpoints used

| # | Endpoint | Purpose |
|---|----------|---------|
| 1 | `GET /NYULeslie` | Establish session |
| 2 | `POST /api/get-data/GetLandingPageLayout` | Get `bookNowLinkId` |
| 3 | `POST /api/get-data/getbooknow` | Get room list with `settingsId`, `meetmeLinkId`, `ownerUserId` |
| 4 | `POST /api/get-availability/calc-ts` | Get all available slots for a month |
| 5 | `POST /api/get-data/SaveSchedulerInviteeDetails` | Submit a booking |

## Env vars

- **Removed:** `ONCEHUB_API_KEY`, `ONCEHUB_SHARED_BOOKING_PROFILE_ID`
- **Kept:** `ONCEHUB_PAGE_URL`, `ONCEHUB_ROOM_LABEL`

## How to configure

Edit `agent/core/clients/booking_profile.json` with your club's booking identity (name, email, NetID, affiliation, school, etc.). Option ID reference tables are included in the JSON as `_*` keys.

## Tests

All 22 tests pass (16 client + 6 MCP service):
```
tests/test_oncehub_client.py       — 16 passed
tests/test_oncehub_mcp_service.py  —  6 passed (no changes needed)
```

MCP tools (`find_oncehub_slots`, `book_oncehub_room`) are unchanged — same public interface, only transport layer replaced.

Closes #52