### PR TITLE
Reconcile runtime docs with agent contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,12 @@ Modal-hosted Python agent code coordinates the systems and is the authoritative 
 
 - `agent/helper/attio.py` wraps Attio API access.
 - `agent/helper/tools.py` contains shared Attio and Convex helpers.
-- `agent/helper/attio.py` wraps Attio API access.
-- `agent/helper/tools.py` contains shared Attio and Convex helpers.
 - `agent/match.py` handles candidate selection.
 - `agent/outreach.py` handles outbound sends.
 - `agent/reply_handler.py` handles inbound email processing.
-- `agent/apps/mcp/service.py` is the packaged FastMCP implementation used by the runtime.
-- `agent/apps/mcp/server.py` is the stdio launcher the runtime starts through the Claude agent SDK.
+- `agent/runtime/anthropic_adapter.py` runs the current in-process tool loop.
+- `agent/apps/mcp/service.py` is the packaged FastMCP-compatible tool implementation for local inspection and compatibility.
+- `agent/apps/mcp/server.py` is the stdio launcher for local tooling, not the canonical production execution path.
 - `agent/mcp_server.py` is a compatibility shim for local tooling and tests.
 - Modal-hosted conversational endpoints own thread runs, approvals, artifacts, and policy.
 - Anthropic Agent SDK is used inside Modal as the harness layer only.
@@ -73,7 +72,7 @@ They may:
 - list threads
 - create or resume threads
 - start runs
-- render streamed output
+- render Convex-reactive message, run, artifact, and approval state
 - render artifacts and approvals
 - submit approval decisions
 
@@ -293,7 +292,7 @@ Do not write historical labels like `warm_intro`, `agent_outreach`, or `inbound`
 4. The client renders the normalized run, message, artifact, and approval state from Convex.
 5. On approval, the client submits the decision back to Modal and the run resumes.
 
-Current MCP tool surface:
+Current tool surface:
 
 - Attio `people` (identity only): `search_people`, `get_person`, `upsert_person`, `append_person_note`
 - Attio `speakers` (workflow): `search_speakers`, `get_speaker`, `ensure_speaker_for_person`, `update_speaker_workflow`

--- a/PLAN.md
+++ b/PLAN.md
@@ -65,8 +65,7 @@ The Modal runtime owns:
 - prompt assembly
 - model execution
 - Anthropic Agent SDK harness lifecycle
-- tool selection and tool execution
-- MCP access
+- tool selection and in-process tool execution
 - approval gating
 - guardrails and policy enforcement
 - artifact generation
@@ -81,15 +80,16 @@ The Anthropic Agent SDK is the runtime harness inside Modal.
 Use it for:
 
 - run orchestration
-- streaming assistant output
 - tool loop management
 - step tracing
 - handoff between model output, tool execution, and approval pauses
 
 Current implementation contract:
 
-- the runtime launches the packaged FastMCP server over stdio from `apps.mcp.server`
-- the Claude agent SDK is the only runtime harness that decides when MCP tools are relevant
+- the runtime uses an in-process tool loop in `agent/runtime/anthropic_adapter.py`
+- no subprocess or MCP stdio transport is required for production run execution
+- local FastMCP utilities remain available for compatibility, inspection, and tests
+- the Claude agent SDK is the harness for model interaction and tool-use turns
 - read tools execute immediately
 - write tools are converted into Modal-managed approvals before execution
 - approved tool calls resume by replaying the exact stored tool name and arguments
@@ -100,11 +100,11 @@ Repo-specific logic must remain in local modules:
 
 - Attio wrappers
 - Convex synchronization
-- MCP adapters
+- in-process tool adapters
 - artifact normalization
 - approval policy and risk classification
 
-Current MCP tool surface:
+Current tool surface:
 
 - Attio `people` (identity only): `search_people`, `get_person`, `upsert_person`, `append_person_note`
 - Attio `speakers` (workflow): `search_speakers`, `get_speaker`, `ensure_speaker_for_person`, `update_speaker_workflow`
@@ -138,17 +138,16 @@ Modal exposes the canonical agent API surface:
 - `GET /agent/threads/:id`
   - return normalized thread, message, artifact, and approval state
 - `POST /agent/runs`
-  - start a run for a thread
-- `GET /agent/runs/:id/stream`
-  - stream assistant output, tool activity, and artifact events
+  - start a run for a thread; the UI observes run progress from Convex-normalized state
 - `POST /agent/approvals/:id`
   - approve or reject a pending action
 
 Implementation rules:
 
 - Modal remains authoritative for run lifecycle and approval state
-- Convex stores synchronized normalized records for UI and history
+- Convex stores synchronized normalized records for UI, live rendering, and history
 - clients render state; they do not decide state
+- no dedicated `GET /agent/runs/:id/stream` route is currently exposed
 
 ## Agent-First UI Contract
 
@@ -156,7 +155,7 @@ The authenticated app should converge on this shape:
 
 - `/agent` as primary landing route
 - left rail for threads and recent work
-- center conversation timeline for streaming responses and approvals
+- center conversation timeline for Convex-reactive messages, run states, and approvals
 - right artifact canvas for rendered outputs
 
 Scoped launchers must exist from:
@@ -429,7 +428,7 @@ Next.js and Discord are thin clients.
 They may:
 
 - start threads or runs
-- render streamed output
+- render Convex-reactive message, run, artifact, and approval state
 - render approvals
 - submit approval decisions
 - deep-link into richer views

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The system is split into three layers:
 | Layer | Responsibility |
 |---|---|
 | `fe+convex/` | Next.js app surfaces, Convex queries/mutations, authenticated UI for `/agent` and dashboard drill-downs |
-| `agent/` | Modal-hosted agent runtime, MCP adapters, Attio/Convex integration helpers, Anthropic Agent SDK harness |
+| `agent/` | Modal-hosted agent runtime, in-process tool adapters, Attio/Convex integration helpers, Anthropic Agent SDK harness |
 | Attio + Convex | Persistent business state: Attio for CRM truth, Convex for application state and agent interaction history |
 
 ## Current MVP Direction
@@ -43,7 +43,7 @@ For the authoritative product and data-contract details, read:
 ```text
 event_organizer/
 ├── fe+convex/              # Next.js 16 app + Convex functions
-├── agent/                  # Modal runtime, Attio helpers, MCP server, tests
+├── agent/                  # Modal runtime, Attio helpers, local MCP utilities, tests
 ├── PLAN.md                 # Architecture and data-contract source of truth
 ├── AGENTS.md               # Operator and runtime integration guide
 ├── IMPLEMENTATION.md       # Implementation workstreams and dependency plan
@@ -110,7 +110,8 @@ cd /Users/sean_lai/event_organizer/agent
 uv sync
 ```
 
-Run the packaged local MCP server if you are working on tool adapters:
+Run the packaged local MCP server only if you are working on tool adapter
+compatibility or local inspection:
 
 ```bash
 cd /Users/sean_lai/event_organizer/agent
@@ -124,7 +125,11 @@ cd /Users/sean_lai/event_organizer/agent
 doppler run -- npx @modelcontextprotocol/inspector uv run python -m apps.mcp.server
 ```
 
-The Modal runtime starts that same MCP server over stdio through the Claude agent SDK. The current tool surface is:
+The production Modal runtime uses an in-process tool loop inside
+`agent/runtime/anthropic_adapter.py`; it does not depend on the local MCP
+server or stdio transport. `POST /agent/runs` starts execution for a thread,
+and the web UI renders live updates from Convex-normalized thread, message,
+artifact, run, and approval records. The current tool surface is:
 
 - Attio `people` (identity only): `search_people`, `get_person`, `upsert_person`, `append_person_note`
 - Attio `speakers` (workflow): `search_speakers`, `get_speaker`, `ensure_speaker_for_person`, `update_speaker_workflow`

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -1,5 +1,10 @@
 # Systems Architecture
 
+> Legacy/reference-only document. `PLAN.md` is the canonical architecture and
+> data-contract source of truth, and `AGENTS.md` is the operator/runtime guide.
+> If this file disagrees with either of those documents, treat `PLAN.md` and
+> `AGENTS.md` as authoritative and update this file only as supporting context.
+
 High-level documentation of how the EventClub backend works — from frontend queries through Convex to the AI agent layer.
 
 ---
@@ -65,7 +70,7 @@ High-level view of every service and how they connect.
     │   (backend/)                │          │                          │
     │   ┌────────────────────┐    │          │  ┌────────────────────┐  │
     │   │ Claude (Anthropic) │    │          │  │   Attio CRM        │  │
-    │   │ via fastmcp tools  │    │          │  │   api.attio.com/v2 │  │
+    │   │ via agent tools    │    │          │  │   api.attio.com/v2 │  │
     │   └────────────────────┘    │          │  │   contact records  │  │
     │   ┌────────────────────┐    │◄────────►│  └────────────────────┘  │
     │   │ AgentMail          │    │          │  ┌────────────────────┐  │
@@ -80,7 +85,7 @@ High-level view of every service and how they connect.
 **Notes:**
 - The frontend is a Next.js app running in the browser, talking to Convex via the Convex React client over WebSocket
 - The Python agent backend runs separately (Modal for serverless deployment) and talks to Convex via HTTP API using a deploy key
-- Both the frontend and the agent backend share the same Convex database — Convex is the single source of truth
+- Both the frontend and the agent backend share the same Convex database for application state; `PLAN.md` remains the documentation source of truth
 - Attio CRM is the contact database; `attio_record_id` is the join key between Attio and Convex
 - AgentMail handles email thread lifecycle; `agentmail_thread_id` links email threads to outreach rows in Convex
 
@@ -298,14 +303,14 @@ The Python agent backend: how Claude reasons and calls tools to manage speaker o
 │                    (backend/ — runs on Modal)                     │
 │                                                                   │
 │  ┌───────────────────────────────────────────────────────────┐   │
-│  │  Claude (claude-sonnet / claude-opus via Anthropic SDK)   │   │
-│  │  Orchestrated via fastmcp tool calling                    │   │
+│  │  Claude via Anthropic SDK                                 │   │
+│  │  Orchestrated by the Modal runtime tool loop              │   │
 │  └───────────────────────────────────────────────────────────┘   │
 │          │                                                        │
 │          │  calls tools                                           │
 │          ▼                                                        │
 │  ┌──────────────────────────────────────────────────────────┐    │
-│  │  MCP Tool Layer (fastmcp)                                │    │
+│  │  Agent Tool Layer                                        │    │
 │  │                                                          │    │
 │  │  Attio Tools                  Convex Tools               │    │
 │  │  ┌──────────────────┐        ┌──────────────────────┐    │    │

--- a/agent/README.md
+++ b/agent/README.md
@@ -15,8 +15,11 @@ It exposes:
 2. `POST /agent/threads`
 3. `GET /agent/threads/:id`
 4. `POST /agent/runs`
-5. `GET /agent/runs/:id/stream`
-6. `POST /agent/approvals/:id`
+5. `POST /agent/approvals/:id`
+
+There is currently no `GET /agent/runs/:id/stream` endpoint. The website starts
+work with `POST /agent/runs` and renders live updates from Convex-normalized
+thread, message, run, artifact, and approval records.
 
 `runtime/modal_app.py` remains as a compatibility entrypoint for existing deploy commands and forwards to the same runtime service.
 
@@ -35,13 +38,13 @@ When a user interacts with the website agent:
 
 1. The UI starts/resumes a thread via `runtime_app.py`.
 2. A run is created and executed in Modal.
-3. The runtime runs the Claude agent SDK harness and launches the packaged FastMCP server over stdio from `apps.mcp.server`.
+3. The runtime runs the Claude agent SDK harness and executes tools through the in-process tool loop in `runtime/anthropic_adapter.py`.
 4. If an action is write/send/destructive, approval gating can pause the run until user decision.
-5. Streamed output, artifacts, and approval states are returned in normalized form for UI rendering.
+5. Messages, artifacts, run status, and approval states are synchronized to Convex for UI rendering.
 
 ## Tool Access Surface
 
-The runtime's current MCP tool surface is:
+The runtime's current tool surface is:
 
 1. **Attio `people` (identity only)**
    - `search_people`
@@ -77,7 +80,7 @@ These are additional root services used by workflow tooling:
 | `match.py` | `event-outreach-match` | Candidate scoring/matching workflow |
 | `outreach.py` | `event-outreach-send` | Outbound invite send workflow |
 | `reply_handler.py` | `event-outreach-replies` | AgentMail webhook ingest and thread routing |
-| `mcp_server.py` | — | Compatibility shim to the packaged FastMCP server |
+| `mcp_server.py` | — | Compatibility shim for local MCP inspection and tests |
 
 ## Running Tests
 
@@ -99,5 +102,5 @@ python -m pytest tests/test_runtime_*.py -v
 | `attio.py` | Attio CRM v2 async HTTP client with retry on 429 |
 | `tools.py` | `ConvexClient` + shared Attio helpers (`upsert_inbound_contact`, `append_attio_note`) |
 | `email_parse.py` | LLM classification (Haiku) + `handle_known_thread` / `handle_net_new` path handlers |
-| `models.py` | Pydantic models for `AttioContact`, `CareerProfile`, `OutreachStatus`, etc. |
+| `models.py` | Pydantic models for Attio people identity and speaker workflow data |
 | `prompts/` | System prompts for LLM classification (`known_thread.txt`, `net_new.txt`) |


### PR DESCRIPTION
Tackled issue #38.

Runtime documentation has been reconciled with the implemented agent contract:

- `POST /agent/runs` is documented as the run-start entrypoint
- Live UI updates are documented as coming from Convex-normalized thread/message/run/artifact/approval state
- The current runtime execution path is documented as the in-process tool loop in `agent/runtime/anthropic_adapter.py`
- FastMCP/stdIO is now described as local inspection/compat tooling, not the production execution path
- `SYSTEMS.md` is marked legacy/reference-only
- `PLAN.md` and `AGENTS.md` are marked as the authoritative docs

Verification:
- Ran `git diff --check`
- No whitespace issues
- No code tests run because this is a docs-only change