### PR TITLE
fix(#8): replace mock communications page with real Convex data

### DIFF
--- a/fe+convex/app/dashboard/communications/[id]/page.tsx
+++ b/fe+convex/app/dashboard/communications/[id]/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery } from "convex/react";
+import { ArrowLeft } from "lucide-react";
+import { DashboardPageShell } from "@/components/dashboard/PageShell";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  formatInboundStateLabel,
+  getThreadContactIdentifier,
+} from "../communicationsView";
+
+function formatDateTime(value?: number | null) {
+  if (!value) return "Not recorded";
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function DetailStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="rounded-[16px] border border-[#E8E8E8] bg-[#FFFFFF] px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#9A9A9A]">
+        {label}
+      </p>
+      <p className="mt-2 text-[16px] font-semibold tracking-[-0.03em] text-[#111111]">{value}</p>
+    </div>
+  );
+}
+
+export default function CommunicationThreadPage() {
+  const params = useParams<{ id: string }>();
+  const thread = useQuery(api.inboundDashboard.getOutreachThread, {
+    id: params.id as Id<"event_outreach">,
+  });
+
+  const contactIdentifier = thread
+    ? getThreadContactIdentifier(thread)
+    : "Loading contact";
+  const statusLabel = thread
+    ? thread.inbound_state_label ?? formatInboundStateLabel(thread.inbound_state)
+    : "Loading status";
+
+  return (
+    <DashboardPageShell
+      title={thread?.event?.title ?? "Thread Detail"}
+      action={
+        <Link
+          href="/dashboard/communications"
+          className="inline-flex items-center gap-2 rounded-full border border-[#E1E1E1] bg-[#FFFFFF] px-3 py-1.5 text-[12px] font-medium text-[#111111] transition hover:bg-[#F6F6F6]"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Inbox
+        </Link>
+      }
+    >
+      {thread === undefined ? (
+        <>
+          <section className="h-[128px] animate-pulse rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF]" />
+          <section className="h-[320px] animate-pulse rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF]" />
+        </>
+      ) : thread === null ? (
+        <section className="rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF] px-6 py-8 text-center">
+          <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-[#111111]">
+            Thread not found
+          </h2>
+          <p className="mt-2 text-[13px] leading-6 text-[#666666]">
+            This outreach thread is not available in Convex. Return to Communications and choose a current thread.
+          </p>
+        </section>
+      ) : (
+        <>
+          <section className="rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF] px-6 py-5">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#949494]">
+              Outreach Thread
+            </p>
+            <h2 className="mt-2 text-[24px] font-semibold tracking-[-0.04em] text-[#111111]">
+              {contactIdentifier}
+            </h2>
+            <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-[13px] text-[#666666]">
+              <span>{thread.contact_email ?? thread.attio_record_id}</span>
+              <span>{thread.event?.title ?? "No linked event"}</span>
+              <span>{statusLabel}</span>
+              <span>{formatDateTime(thread.last_activity_at)}</span>
+            </div>
+          </section>
+
+          <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <DetailStat label="Status" value={statusLabel} />
+            <DetailStat label="Messages" value={thread.message_count} />
+            <DetailStat label="Attio Person" value={thread.attio_record_id} />
+            <DetailStat
+              label="Speaker Entry"
+              value={thread.attio_speakers_entry_id ?? "Not linked"}
+            />
+          </section>
+
+          <section className="grid gap-5 xl:grid-cols-[320px_minmax(0,1fr)]">
+            <aside className="rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF] p-5">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#9A9A9A]">
+                Linked Event
+              </p>
+              <div className="mt-4 space-y-3 text-[13px] text-[#666666]">
+                <div>
+                  <p className="font-medium text-[#111111]">Title</p>
+                  <p className="mt-1">{thread.event?.title ?? "Unavailable"}</p>
+                </div>
+                <div>
+                  <p className="font-medium text-[#111111]">Date</p>
+                  <p className="mt-1">{thread.event?.event_date ?? "Not scheduled"}</p>
+                </div>
+                <div>
+                  <p className="font-medium text-[#111111]">Time</p>
+                  <p className="mt-1">{thread.event?.event_time ?? "Not scheduled"}</p>
+                </div>
+                <div>
+                  <p className="font-medium text-[#111111]">Event Status</p>
+                  <p className="mt-1">{thread.event?.status ?? "Unknown"}</p>
+                </div>
+              </div>
+            </aside>
+
+            <section className="rounded-[20px] border border-[#EAEAEA] bg-[#FFFFFF]">
+              <div className="border-b border-[#EFEFEF] px-5 py-5">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#9F9F9F]">
+                  Receipt Timeline
+                </p>
+                <h3 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#111111]">
+                  Inbound processing history
+                </h3>
+                <p className="mt-2 text-[13px] leading-6 text-[#6C6C6C]">
+                  Chronological receipt records linked to this outreach thread.
+                </p>
+              </div>
+
+              {thread.receipts.length > 0 ? (
+                <div className="px-5 py-4">
+                  {thread.receipts.map((receipt, index) => (
+                    <div key={receipt._id} className="flex gap-3 py-3">
+                      <div className="flex w-8 flex-col items-center">
+                        <div className="h-2.5 w-2.5 rounded-full border border-[#D7D7D7] bg-[#111111]" />
+                        {index < thread.receipts.length - 1 ? (
+                          <div className="mt-2 h-full w-px bg-[#ECECEC]" />
+                        ) : null}
+                      </div>
+                      <div className="flex-1 rounded-[16px] border border-[#F0F0F0] bg-[#FCFCFC] px-4 py-3">
+                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                          <div className="min-w-0">
+                            <p className="text-[13px] font-semibold text-[#111111]">
+                              {receipt.message_id}
+                            </p>
+                            <p className="mt-1 text-[12px] text-[#7A7A7A]">
+                              Received {formatDateTime(receipt.received_at)}
+                            </p>
+                          </div>
+                          <div className="shrink-0 text-left md:text-right">
+                            <span className="inline-flex rounded-full border border-[#DADADA] bg-[#FFFFFF] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#444444]">
+                              {receipt.status ?? "unknown"}
+                            </span>
+                            <p className="mt-2 text-[11px] text-[#7A7A7A]">
+                              Updated {formatDateTime(receipt.updated_at ?? receipt.completed_at)}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-5 py-10 text-center">
+                  <h3 className="text-[16px] font-semibold text-[#151515]">No inbound receipts yet</h3>
+                  <p className="mt-2 text-[13px] leading-6 text-[#747474]">
+                    This thread has not recorded receipt processing metadata in Convex yet.
+                  </p>
+                </div>
+              )}
+            </section>
+          </section>
+        </>
+      )}
+    </DashboardPageShell>
+  );
+}

--- a/fe+convex/app/dashboard/communications/communications.test.ts
+++ b/fe+convex/app/dashboard/communications/communications.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildOutreachThreadHref,
+  formatInboundStateLabel,
+  matchesThreadSearch,
+  selectVisibleThreads,
+  toInboxRowModel,
+  type OutreachInboxThread,
+} from "./communicationsView";
+
+const FIXTURE_THREADS: OutreachInboxThread[] = [
+  {
+    _id: "event_outreach:1",
+    attio_record_id: "person_1",
+    attio_speakers_entry_id: "speaker_1",
+    inbound_state: "needs_review",
+    inbound_state_label: "Needs Review",
+    event_name: "AI & Society Panel",
+    contact_name: "Sarah Chen",
+    contact_email: "sarah@example.com",
+    contact_identifier: "Sarah Chen",
+    message_count: 3,
+    last_activity_at: 300,
+  },
+  {
+    _id: "event_outreach:2",
+    attio_record_id: "person_2",
+    inbound_state: "awaiting_member_reply",
+    inbound_state_label: "Awaiting Reply",
+    event_name: "Web3 Workshop",
+    contact_name: null,
+    contact_email: "james@example.com",
+    contact_identifier: "james@example.com",
+    message_count: 2,
+    last_activity_at: 200,
+  },
+  {
+    _id: "event_outreach:3",
+    attio_record_id: "person_3",
+    inbound_state: "resolved",
+    inbound_state_label: "Resolved",
+    event_name: "Networking Mixer",
+    contact_name: null,
+    contact_email: null,
+    contact_identifier: "person_3",
+    message_count: 1,
+    last_activity_at: 100,
+  },
+];
+
+describe("communications view helpers", () => {
+  test("filter tabs toggle visible rows by inbound_state", () => {
+    expect(selectVisibleThreads(FIXTURE_THREADS, "all", "")).toHaveLength(3);
+    expect(selectVisibleThreads(FIXTURE_THREADS, "needs_review", "")).toHaveLength(1);
+    expect(selectVisibleThreads(FIXTURE_THREADS, "awaiting_member_reply", "")).toHaveLength(1);
+    expect(selectVisibleThreads(FIXTURE_THREADS, "resolved", "")).toHaveLength(1);
+  });
+
+  test("search narrows rows by contact name and email", () => {
+    expect(selectVisibleThreads(FIXTURE_THREADS, "all", "sarah")).toHaveLength(1);
+    expect(selectVisibleThreads(FIXTURE_THREADS, "all", "james@example.com")).toHaveLength(1);
+  });
+
+  test("search narrows rows by event name", () => {
+    const visible = selectVisibleThreads(FIXTURE_THREADS, "all", "networking");
+    expect(visible).toHaveLength(1);
+    expect(visible[0].event_name).toBe("Networking Mixer");
+  });
+
+  test("falls back to attio_record_id when contact fields are missing", () => {
+    const row = toInboxRowModel(FIXTURE_THREADS[2]);
+    expect(row.contactLine).toBe("person_3");
+  });
+
+  test("View thread routes to the detail surface", () => {
+    expect(buildOutreachThreadHref("event_outreach:2")).toBe(
+      "/dashboard/communications/event_outreach:2"
+    );
+    expect(toInboxRowModel(FIXTURE_THREADS[1]).href).toBe(
+      "/dashboard/communications/event_outreach:2"
+    );
+  });
+});
+
+describe("communications integration fixtures", () => {
+  test("fixture rows expose the correct badge labels and counts for each filter", () => {
+    const allRows = selectVisibleThreads(FIXTURE_THREADS, "all", "").map(toInboxRowModel);
+    expect(allRows).toHaveLength(3);
+    expect(allRows.map((row) => row.statusLabel)).toEqual([
+      "Needs Review",
+      "Awaiting Reply",
+      "Resolved",
+    ]);
+
+    const needsReview = selectVisibleThreads(FIXTURE_THREADS, "needs_review", "").map(toInboxRowModel);
+    expect(needsReview).toHaveLength(1);
+    expect(needsReview[0].statusLabel).toBe(formatInboundStateLabel("needs_review"));
+
+    const awaiting = selectVisibleThreads(
+      FIXTURE_THREADS,
+      "awaiting_member_reply",
+      ""
+    ).map(toInboxRowModel);
+    expect(awaiting).toHaveLength(1);
+    expect(awaiting[0].statusLabel).toBe("Awaiting Reply");
+
+    const resolved = selectVisibleThreads(FIXTURE_THREADS, "resolved", "").map(toInboxRowModel);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].statusLabel).toBe("Resolved");
+  });
+
+  test("matchesThreadSearch checks the same fields shown in the inbox", () => {
+    expect(matchesThreadSearch(FIXTURE_THREADS[0], "AI & Society")).toBe(true);
+    expect(matchesThreadSearch(FIXTURE_THREADS[1], "james@example.com")).toBe(true);
+    expect(matchesThreadSearch(FIXTURE_THREADS[2], "person_3")).toBe(true);
+    expect(matchesThreadSearch(FIXTURE_THREADS[2], "missing")).toBe(false);
+  });
+});

--- a/fe+convex/app/dashboard/communications/communicationsView.ts
+++ b/fe+convex/app/dashboard/communications/communicationsView.ts
@@ -1,0 +1,119 @@
+export type InboxFilter = "all" | "needs_review" | "awaiting_member_reply" | "resolved";
+
+export type OutreachInboxThread = {
+  _id: string;
+  attio_record_id: string;
+  attio_speakers_entry_id?: string | null;
+  response?: string | null;
+  inbound_state?: string | null;
+  inbound_state_label?: string | null;
+  event_id?: string;
+  event_name: string;
+  contact_name?: string | null;
+  contact_email?: string | null;
+  contact_identifier?: string | null;
+  message_count: number;
+  last_activity_at: number;
+};
+
+export const INBOX_FILTERS: InboxFilter[] = [
+  "all",
+  "needs_review",
+  "awaiting_member_reply",
+  "resolved",
+];
+
+export function formatInboundStateLabel(state?: string | null) {
+  if (state === "awaiting_member_reply") return "Awaiting Reply";
+  if (state === "resolved") return "Resolved";
+  return "Needs Review";
+}
+
+export function formatInboxFilterLabel(filter: InboxFilter) {
+  if (filter === "all") return "All";
+  return formatInboundStateLabel(filter);
+}
+
+export function getThreadContactIdentifier(
+  thread: Pick<
+    OutreachInboxThread,
+    "attio_record_id" | "contact_identifier" | "contact_name" | "contact_email"
+  >
+) {
+  return (
+    thread.contact_identifier ??
+    thread.contact_name ??
+    thread.contact_email ??
+    thread.attio_record_id
+  );
+}
+
+export function getThreadContactLine(
+  thread: Pick<
+    OutreachInboxThread,
+    "attio_record_id" | "contact_identifier" | "contact_name" | "contact_email"
+  >
+) {
+  if (thread.contact_name && thread.contact_email) {
+    return `${thread.contact_name} / ${thread.contact_email}`;
+  }
+  return getThreadContactIdentifier(thread);
+}
+
+export function buildOutreachThreadHref(id: string) {
+  return `/dashboard/communications/${id}`;
+}
+
+export function getThreadStatusLabel(
+  thread: Pick<OutreachInboxThread, "inbound_state" | "inbound_state_label">
+) {
+  return thread.inbound_state_label ?? formatInboundStateLabel(thread.inbound_state);
+}
+
+export function filterThreadsByState(
+  threads: OutreachInboxThread[],
+  filter: InboxFilter
+) {
+  if (filter === "all") return threads;
+  return threads.filter((thread) => (thread.inbound_state ?? "needs_review") === filter);
+}
+
+export function matchesThreadSearch(
+  thread: Pick<
+    OutreachInboxThread,
+    "attio_record_id" | "contact_identifier" | "contact_name" | "contact_email" | "event_name"
+  >,
+  search: string
+) {
+  const query = search.trim().toLowerCase();
+  if (!query) return true;
+
+  return [
+    thread.event_name,
+    thread.contact_name ?? "",
+    thread.contact_email ?? "",
+    thread.contact_identifier ?? "",
+    thread.attio_record_id,
+  ].some((value) => value.toLowerCase().includes(query));
+}
+
+export function selectVisibleThreads(
+  threads: OutreachInboxThread[],
+  filter: InboxFilter,
+  search: string
+) {
+  return filterThreadsByState(threads, filter).filter((thread) =>
+    matchesThreadSearch(thread, search)
+  );
+}
+
+export function toInboxRowModel(thread: OutreachInboxThread) {
+  return {
+    id: thread._id,
+    title: thread.event_name,
+    contactLine: getThreadContactLine(thread),
+    statusLabel: getThreadStatusLabel(thread),
+    href: buildOutreachThreadHref(thread._id),
+    messageLabel: `${thread.message_count} message${thread.message_count === 1 ? "" : "s"}`,
+  };
+}

--- a/fe+convex/app/dashboard/communications/page.tsx
+++ b/fe+convex/app/dashboard/communications/page.tsx
@@ -1,72 +1,60 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useQuery } from "convex/react";
 import { DashboardPageShell } from "@/components/dashboard/PageShell";
+import { api } from "@/convex/_generated/api";
+import {
+  formatInboxFilterLabel,
+  getThreadStatusLabel,
+  INBOX_FILTERS,
+  selectVisibleThreads,
+  toInboxRowModel,
+  type InboxFilter,
+} from "./communicationsView";
 
-const mockThreads = [
-  {
-    id: "1",
-    subject: "Speaking opportunity at AI & Society Panel",
-    speaker: "Sarah Chen",
-    from: "sarah@example.com",
-    status: "resolved",
-    messages: 5,
-    lastMessage: "2026-03-10",
-  },
-  {
-    id: "2",
-    subject: "Web3 workshop format questions",
-    speaker: "James Wilson",
-    from: "james@example.com",
-    status: "awaiting_reply",
-    messages: 2,
-    lastMessage: "2026-03-08",
-  },
-  {
-    id: "3",
-    subject: "Availability for networking mixer",
-    speaker: "Maria Garcia",
-    from: "maria@example.com",
-    status: "needs_review",
-    messages: 3,
-    lastMessage: "2026-03-06",
-  },
-];
+function formatLastActivity(value: number) {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
 
-function formatStatus(status: string) {
-  if (status === "awaiting_reply") return "Awaiting Reply";
-  if (status === "needs_review") return "Needs Review";
-  return "Resolved";
+function getStatusBadgeClasses(state?: string | null) {
+  if (state === "resolved") {
+    return "border border-[#DADADA] bg-[#FFFFFF] text-[#666666]";
+  }
+  if (state === "awaiting_member_reply") {
+    return "border border-[#DADADA] bg-[#F4F4F4] text-[#2F2F2F]";
+  }
+  return "border border-[#111111] bg-[#111111] text-[#FFFFFF]";
 }
 
 export default function CommunicationsPage() {
-  const [filter, setFilter] = useState<string>("all");
+  const [filter, setFilter] = useState<InboxFilter>("all");
   const [search, setSearch] = useState("");
+  const threads = useQuery(api.inboundDashboard.listOutreachThreads, { filter });
 
-  const filteredThreads = mockThreads.filter((thread) => {
-    const matchesFilter = filter === "all" || thread.status === filter;
-    const matchesSearch =
-      thread.subject.toLowerCase().includes(search.toLowerCase()) ||
-      thread.speaker.toLowerCase().includes(search.toLowerCase()) ||
-      thread.from.toLowerCase().includes(search.toLowerCase());
-    return matchesFilter && matchesSearch;
-  });
+  const visibleThreads = useMemo(
+    () => selectVisibleThreads(threads ?? [], filter, search),
+    [filter, search, threads]
+  );
 
   return (
-    <DashboardPageShell
-      title="Communications"
-    >
+    <DashboardPageShell title="Communications">
       <section className="rounded-[14px] border border-[#EBEBEB] bg-[#FFFFFF] p-4">
         <div className="flex flex-col gap-3 xl:flex-row">
           <input
             type="text"
             placeholder="Search threads"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(event) => setSearch(event.target.value)}
             className="h-10 w-full rounded-[8px] border border-[#E0E0E0] bg-transparent px-[14px] text-[14px] font-normal tracking-[-0.01em] text-[#111111] placeholder:font-normal placeholder:tracking-normal placeholder:text-[#999999] outline-none transition focus:border-[#111111]"
           />
           <div className="flex flex-wrap gap-2">
-            {["all", "needs_review", "awaiting_reply", "resolved"].map((status) => (
+            {INBOX_FILTERS.map((status) => (
               <button
                 key={status}
                 onClick={() => setFilter(status)}
@@ -76,7 +64,7 @@ export default function CommunicationsPage() {
                     : "border border-[#E0E0E0] text-[#555555] hover:bg-[#F4F4F4]"
                 }`}
               >
-                {status === "all" ? "All" : formatStatus(status)}
+                {formatInboxFilterLabel(status)}
               </button>
             ))}
           </div>
@@ -84,36 +72,56 @@ export default function CommunicationsPage() {
       </section>
 
       <section className="overflow-hidden rounded-[14px] border border-[#EBEBEB] bg-[#FFFFFF]">
-        {filteredThreads.length > 0 ? (
+        {threads === undefined ? (
           <div className="divide-y divide-[#EBEBEB]">
-            {filteredThreads.map((thread) => (
-              <article key={thread.id} className="px-4 py-3.5 hover:bg-[#FAFAFA]">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="space-y-1">
-                    <h2 className="text-[14px] font-semibold text-[#111111]">{thread.subject}</h2>
-                    <p className="text-[12px] text-[#999999]">
-                      {thread.speaker} · {thread.from}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-[12px] font-medium text-[#3B3B3B]">
-                      {formatStatus(thread.status)}
-                    </p>
-                    <p className="text-[12px] text-[#7B7B7B]">
-                      {new Date(thread.lastMessage).toLocaleDateString()}
-                    </p>
-                  </div>
-                </div>
-                <div className="mt-2.5 flex items-center justify-between text-[12px] text-[#6B6B6B]">
-                  <span>
-                    {thread.messages} message{thread.messages === 1 ? "" : "s"}
-                  </span>
-                  <button className="font-medium text-[#555555] transition hover:text-[#111111]">
-                    View thread
-                  </button>
-                </div>
-              </article>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-[84px] animate-pulse bg-[linear-gradient(180deg,#FFFFFF_0%,#FAFAFA_100%)] px-4 py-3.5"
+              />
             ))}
+          </div>
+        ) : visibleThreads.length > 0 ? (
+          <div className="divide-y divide-[#EBEBEB]">
+            {visibleThreads.map((thread) => {
+              const row = toInboxRowModel(thread);
+              return (
+                <article
+                  key={thread._id}
+                  className="px-4 py-3.5 transition hover:bg-[#FAFAFA]"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 space-y-1">
+                      <h2 className="truncate text-[14px] font-semibold text-[#111111]">
+                        {row.title}
+                      </h2>
+                      <p className="truncate text-[12px] text-[#999999]">{row.contactLine}</p>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <span
+                        className={`inline-flex rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${getStatusBadgeClasses(
+                          thread.inbound_state
+                        )}`}
+                      >
+                        {getThreadStatusLabel(thread)}
+                      </span>
+                      <p className="mt-2 text-[12px] text-[#7B7B7B]">
+                        {formatLastActivity(thread.last_activity_at)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-2.5 flex items-center justify-between text-[12px] text-[#6B6B6B]">
+                    <span>{row.messageLabel}</span>
+                    <Link
+                      href={row.href}
+                      className="font-medium text-[#555555] transition hover:text-[#111111]"
+                    >
+                      View thread
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
           </div>
         ) : (
           <div className="p-8 text-center text-[14px] text-[#6B6B6B]">No threads found</div>

--- a/fe+convex/convex/inboundDashboard.test.ts
+++ b/fe+convex/convex/inboundDashboard.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, test } from "bun:test";
+
+import { getOutreachThread, listOutreachThreads } from "./inboundDashboard";
+
+type TableName = "events" | "event_outreach" | "inbound_receipts";
+type TableRow = { _id: string } & Record<string, unknown>;
+type Tables = Record<TableName, TableRow[]>;
+
+class FakeIndexRangeBuilder {
+  readonly filters: Array<[string, unknown]> = [];
+
+  eq(field: string, value: unknown) {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+class FakeQuery {
+  constructor(private readonly rows: TableRow[], private readonly filters: Array<[string, unknown]> = []) {}
+
+  withIndex(_indexName: string, build: (builder: FakeIndexRangeBuilder) => unknown) {
+    const builder = new FakeIndexRangeBuilder();
+    build(builder);
+    return new FakeQuery(this.rows, builder.filters);
+  }
+
+  order(_direction: "asc" | "desc") {
+    return this;
+  }
+
+  async collect() {
+    return this.rows.filter((row) => this.filters.every(([field, value]) => row[field] === value));
+  }
+
+  async first() {
+    const matches = await this.collect();
+    return matches[0] ?? null;
+  }
+
+  async unique() {
+    const matches = await this.collect();
+    return matches[0] ?? null;
+  }
+}
+
+class FakeDb {
+  private readonly counters: Record<TableName, number> = {
+    events: 0,
+    event_outreach: 0,
+    inbound_receipts: 0,
+  };
+
+  readonly tables: Tables = {
+    events: [],
+    event_outreach: [],
+    inbound_receipts: [],
+  };
+
+  query(table: TableName) {
+    return new FakeQuery(this.tables[table]);
+  }
+
+  async get(id: string) {
+    const table = id.split(":")[0] as TableName;
+    return this.tables[table].find((row) => row._id === id) ?? null;
+  }
+
+  async insert(table: TableName, value: Record<string, unknown>) {
+    const id = `${table}:${++this.counters[table]}`;
+    this.tables[table].push({ _id: id, ...value });
+    return id;
+  }
+}
+
+function getHandler<TArgs, TResult>(fn: unknown) {
+  const wrapped = fn as {
+    handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+    _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+  };
+  const handler = wrapped.handler ?? wrapped._handler;
+  if (!handler) {
+    throw new Error("Convex handler is unavailable in test harness");
+  }
+  return handler;
+}
+
+function installConvexHandlerAliases() {
+  for (const fn of [listOutreachThreads, getOutreachThread]) {
+    const wrapped = fn as typeof fn & { handler?: unknown; _handler?: unknown };
+    if (!wrapped.handler) {
+      wrapped.handler = wrapped._handler;
+    }
+  }
+}
+
+function createHarness() {
+  installConvexHandlerAliases();
+  const db = new FakeDb();
+  return { db, ctx: { db } };
+}
+
+async function seedEvent(db: FakeDb, title: string, createdAt: number) {
+  return await db.insert("events", {
+    title,
+    description: `${title} description`,
+    event_date: "2026-05-01",
+    event_time: "6:00 PM",
+    status: "outreach",
+    needs_outreach: true,
+    created_at: createdAt,
+  });
+}
+
+async function seedOutreach(
+  db: FakeDb,
+  overrides: Record<string, unknown> = {}
+) {
+  const defaultEventId =
+    db.tables.events[0]?._id ?? (await seedEvent(db, "Fallback Event", 1));
+  return await db.insert("event_outreach", {
+    event_id: defaultEventId,
+    attio_record_id: "person_default",
+    attio_speakers_entry_id: undefined,
+    contact_name: undefined,
+    contact_email: undefined,
+    suggested: true,
+    approved: true,
+    outreach_sent: true,
+    response: "pending",
+    inbound_state: "needs_review",
+    inbound_count: 0,
+    created_at: 1,
+    ...overrides,
+  });
+}
+
+describe("inboundDashboard inbox queries", () => {
+  test("listOutreachThreads returns all rows and filters by inbound_state", async () => {
+    const { db, ctx } = createHarness();
+    const summitId = await seedEvent(db, "AI Summit", 1);
+    const workshopId = await seedEvent(db, "Builders Workshop", 2);
+    const mixerId = await seedEvent(db, "Founder Mixer", 3);
+
+    await seedOutreach(db, {
+      event_id: summitId,
+      attio_record_id: "person_1",
+      attio_speakers_entry_id: "speaker_1",
+      contact_name: "Sarah Chen",
+      contact_email: "sarah@example.com",
+      inbound_state: "needs_review",
+      inbound_count: 2,
+      last_inbound_at: 400,
+      agentmail_thread_id: "thread-needs-review",
+      created_at: 100,
+    });
+    await seedOutreach(db, {
+      event_id: workshopId,
+      attio_record_id: "person_2",
+      inbound_state: "awaiting_member_reply",
+      inbound_count: 1,
+      last_inbound_at: 500,
+      agentmail_thread_id: "thread-awaiting",
+      created_at: 200,
+    });
+    await seedOutreach(db, {
+      event_id: mixerId,
+      attio_record_id: "person_3",
+      contact_email: "maria@example.com",
+      inbound_state: "resolved",
+      inbound_count: 3,
+      last_inbound_at: 300,
+      agentmail_thread_id: "thread-resolved",
+      created_at: 300,
+    });
+
+    const allThreads = await getHandler<
+      { filter?: "all" | "needs_review" | "awaiting_member_reply" | "resolved" },
+      Array<Record<string, unknown>>
+    >(listOutreachThreads)(ctx as never, { filter: "all" });
+
+    expect(allThreads).toHaveLength(3);
+    expect(allThreads.map((row) => row.inbound_state)).toEqual([
+      "awaiting_member_reply",
+      "needs_review",
+      "resolved",
+    ]);
+    expect(allThreads[0]).toMatchObject({
+      event_name: "Builders Workshop",
+      inbound_state_label: "Awaiting Reply",
+      contact_identifier: "person_2",
+    });
+    expect(allThreads[1]).toMatchObject({
+      attio_speakers_entry_id: "speaker_1",
+      contact_name: "Sarah Chen",
+      contact_email: "sarah@example.com",
+      contact_identifier: "Sarah Chen",
+      inbound_state_label: "Needs Review",
+      message_count: 2,
+    });
+    expect(allThreads[2]).toMatchObject({
+      inbound_state_label: "Resolved",
+      contact_identifier: "maria@example.com",
+    });
+
+    const needsReview = await getHandler<
+      { filter?: "all" | "needs_review" | "awaiting_member_reply" | "resolved" },
+      Array<Record<string, unknown>>
+    >(listOutreachThreads)(ctx as never, { filter: "needs_review" });
+    expect(needsReview).toHaveLength(1);
+    expect(needsReview[0].attio_record_id).toBe("person_1");
+
+    const awaitingReply = await getHandler<
+      { filter?: "all" | "needs_review" | "awaiting_member_reply" | "resolved" },
+      Array<Record<string, unknown>>
+    >(listOutreachThreads)(ctx as never, { filter: "awaiting_member_reply" });
+    expect(awaitingReply).toHaveLength(1);
+    expect(awaitingReply[0].attio_record_id).toBe("person_2");
+
+    const resolved = await getHandler<
+      { filter?: "all" | "needs_review" | "awaiting_member_reply" | "resolved" },
+      Array<Record<string, unknown>>
+    >(listOutreachThreads)(ctx as never, { filter: "resolved" });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].attio_record_id).toBe("person_3");
+  });
+
+  test("listOutreachThreads falls back to receipts for message count and activity", async () => {
+    const { db, ctx } = createHarness();
+    const eventId = await seedEvent(db, "Fallback Event", 1);
+    await seedOutreach(db, {
+      event_id: eventId,
+      attio_record_id: "person_fallback",
+      inbound_state: undefined,
+      inbound_count: undefined,
+      last_inbound_at: undefined,
+      agentmail_thread_id: "thread-fallback",
+      created_at: 25,
+    });
+
+    await db.insert("inbound_receipts", {
+      message_id: "msg_1",
+      thread_id: "thread-fallback",
+      received_at: 120,
+      status: "completed",
+    });
+    await db.insert("inbound_receipts", {
+      message_id: "msg_2",
+      thread_id: "thread-fallback",
+      received_at: 240,
+      status: "completed",
+    });
+
+    const rows = await getHandler<
+      { filter?: "all" | "needs_review" | "awaiting_member_reply" | "resolved" },
+      Array<Record<string, unknown>>
+    >(listOutreachThreads)(ctx as never, {});
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      inbound_state: "needs_review",
+      inbound_state_label: "Needs Review",
+      message_count: 2,
+      last_activity_at: 240,
+      contact_identifier: "person_fallback",
+    });
+  });
+
+  test("getOutreachThread returns receipts in chronological order", async () => {
+    const { db, ctx } = createHarness();
+    const eventId = await seedEvent(db, "Inbox Detail Event", 1);
+    const outreachId = await seedOutreach(db, {
+      event_id: eventId,
+      attio_record_id: "person_detail",
+      contact_name: "Jordan Lee",
+      contact_email: "jordan@example.com",
+      attio_speakers_entry_id: "speaker_detail",
+      inbound_state: "awaiting_member_reply",
+      inbound_count: undefined,
+      last_inbound_at: undefined,
+      agentmail_thread_id: "thread-detail",
+      created_at: 15,
+    });
+
+    await db.insert("inbound_receipts", {
+      message_id: "message_b",
+      thread_id: "thread-detail",
+      received_at: 300,
+      status: "processing",
+      updated_at: 330,
+    });
+    await db.insert("inbound_receipts", {
+      message_id: "message_a",
+      thread_id: "thread-detail",
+      received_at: 100,
+      status: "completed",
+      updated_at: 140,
+    });
+    await db.insert("inbound_receipts", {
+      message_id: "message_c",
+      thread_id: "thread-detail",
+      received_at: 200,
+      status: "completed",
+      updated_at: 210,
+    });
+
+    const result = await getHandler<{ id: string }, Record<string, unknown> | null>(
+      getOutreachThread
+    )(ctx as never, { id: outreachId });
+
+    expect(result).not.toBeNull();
+    expect(result).toMatchObject({
+      _id: outreachId,
+      attio_record_id: "person_detail",
+      attio_speakers_entry_id: "speaker_detail",
+      contact_name: "Jordan Lee",
+      contact_email: "jordan@example.com",
+      contact_identifier: "Jordan Lee",
+      inbound_state: "awaiting_member_reply",
+      inbound_state_label: "Awaiting Reply",
+      message_count: 3,
+      last_activity_at: 300,
+      event: {
+        _id: eventId,
+        title: "Inbox Detail Event",
+      },
+    });
+    expect((result?.receipts as Array<{ message_id: string }>).map((receipt) => receipt.message_id)).toEqual([
+      "message_a",
+      "message_c",
+      "message_b",
+    ]);
+  });
+});

--- a/fe+convex/convex/inboundDashboard.ts
+++ b/fe+convex/convex/inboundDashboard.ts
@@ -2,6 +2,40 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { authComponent } from "./auth";
 
+const inboundStateFilterValidator = v.union(
+  v.literal("all"),
+  v.literal("needs_review"),
+  v.literal("awaiting_member_reply"),
+  v.literal("resolved")
+);
+
+function normalizeInboundState(value?: string | null) {
+  return value ?? "needs_review";
+}
+
+function formatInboundStateLabel(state?: string | null) {
+  const normalized = normalizeInboundState(state);
+  if (normalized === "awaiting_member_reply") return "Awaiting Reply";
+  if (normalized === "resolved") return "Resolved";
+  return "Needs Review";
+}
+
+function getLastActivityAt(
+  row: {
+    last_inbound_at?: number | null;
+    created_at: number;
+  },
+  receipts: Array<{
+    received_at: number;
+  }>
+) {
+  const latestReceiptAt = receipts.reduce(
+    (latest, receipt) => Math.max(latest, receipt.received_at),
+    0
+  );
+  return row.last_inbound_at ?? (latestReceiptAt || row.created_at);
+}
+
 function summarizeOutreach(rows: Array<Record<string, unknown>>) {
   return {
     threads: rows.length,
@@ -14,6 +48,110 @@ function summarizeOutreach(rows: Array<Record<string, unknown>>) {
     resolved: rows.filter((row) => row.inbound_state === "resolved").length,
   };
 }
+
+export const listOutreachThreads = query({
+  args: {
+    filter: v.optional(inboundStateFilterValidator),
+  },
+  handler: async (ctx, { filter }) => {
+    const [rows, receipts] = await Promise.all([
+      ctx.db.query("event_outreach").collect(),
+      ctx.db.query("inbound_receipts").collect(),
+    ]);
+
+    const receiptsByThreadId = new Map<string, typeof receipts>();
+    for (const receipt of receipts) {
+      if (!receipt.thread_id) continue;
+      const threadReceipts = receiptsByThreadId.get(receipt.thread_id) ?? [];
+      threadReceipts.push(receipt);
+      receiptsByThreadId.set(receipt.thread_id, threadReceipts);
+    }
+
+    const filteredRows = rows.filter((row) => {
+      if (!filter || filter === "all") return true;
+      return normalizeInboundState(row.inbound_state) === filter;
+    });
+
+    const threadRows = await Promise.all(
+      filteredRows.map(async (row) => {
+        const event = await ctx.db.get(row.event_id);
+        const threadReceipts = row.agentmail_thread_id
+          ? receiptsByThreadId.get(row.agentmail_thread_id) ?? []
+          : [];
+        const lastActivityAt = getLastActivityAt(row, threadReceipts);
+        return {
+          _id: row._id,
+          attio_record_id: row.attio_record_id,
+          attio_speakers_entry_id: row.attio_speakers_entry_id ?? null,
+          response: row.response ?? "pending",
+          inbound_state: normalizeInboundState(row.inbound_state),
+          inbound_state_label: formatInboundStateLabel(row.inbound_state),
+          event_id: row.event_id,
+          event_name: event?.title ?? "Untitled event",
+          contact_name: row.contact_name ?? null,
+          contact_email: row.contact_email ?? null,
+          contact_identifier:
+            row.contact_name ?? row.contact_email ?? row.attio_record_id,
+          message_count: row.inbound_count ?? threadReceipts.length,
+          last_activity_at: lastActivityAt,
+        };
+      })
+    );
+
+    return threadRows.sort((left, right) => right.last_activity_at - left.last_activity_at);
+  },
+});
+
+export const getOutreachThread = query({
+  args: {
+    id: v.id("event_outreach"),
+  },
+  handler: async (ctx, { id }) => {
+    const row = await ctx.db.get(id);
+    if (!row) return null;
+
+    const [event, receipts] = await Promise.all([
+      ctx.db.get(row.event_id),
+      ctx.db.query("inbound_receipts").collect(),
+    ]);
+
+    const threadReceipts = row.agentmail_thread_id
+      ? receipts
+          .filter((receipt) => receipt.thread_id === row.agentmail_thread_id)
+          .sort((left, right) => {
+            const timeDelta = left.received_at - right.received_at;
+            if (timeDelta !== 0) return timeDelta;
+            const updatedLeft = left.updated_at ?? left.completed_at ?? left.processing_started_at ?? 0;
+            const updatedRight =
+              right.updated_at ?? right.completed_at ?? right.processing_started_at ?? 0;
+            if (updatedLeft !== updatedRight) return updatedLeft - updatedRight;
+            return left.message_id.localeCompare(right.message_id);
+          })
+      : [];
+
+    return {
+      ...row,
+      attio_speakers_entry_id: row.attio_speakers_entry_id ?? null,
+      contact_name: row.contact_name ?? null,
+      contact_email: row.contact_email ?? null,
+      contact_identifier: row.contact_name ?? row.contact_email ?? row.attio_record_id,
+      inbound_state: normalizeInboundState(row.inbound_state),
+      inbound_state_label: formatInboundStateLabel(row.inbound_state),
+      message_count: row.inbound_count ?? threadReceipts.length,
+      last_activity_at: getLastActivityAt(row, threadReceipts),
+      event: event
+        ? {
+            _id: event._id,
+            title: event.title,
+            event_date: event.event_date ?? null,
+            event_time: event.event_time ?? null,
+            status: event.status,
+          }
+        : null,
+      receipts: threadReceipts,
+    };
+  },
+});
 
 export const getEventInboundStatus = query({
   args: { event_id: v.optional(v.id("events")) },

--- a/fe+convex/convex/schema.ts
+++ b/fe+convex/convex/schema.ts
@@ -24,6 +24,9 @@ export default defineSchema({
   event_outreach: defineTable({
     event_id: v.id("events"),
     attio_record_id: v.string(),
+    attio_speakers_entry_id: v.optional(v.string()),
+    contact_name: v.optional(v.string()),
+    contact_email: v.optional(v.string()),
     suggested: v.boolean(),
     approved: v.boolean(),
     outreach_sent: v.boolean(),


### PR DESCRIPTION
1. event_outreach schema extended with three optional fields: contact_name, contact_email, attio_speakers_entry_id — all optional so no existing rows are affected
2. inboundDashboard.ts now exposes listOutreachThreads (with filter + event join) and getOutreachThread (with chronological receipt timeline)
3, Communications page replaced mock data with useQuery(api.inboundDashboard.listOutreachThreads), client-side search, and real status tab filtering
4, New thread detail route at /dashboard/communications/[id] makes View thread functional
5. Pure-logic helpers extracted to communicationsView.ts for testability without a render harness
6. Tests added for Convex queries and frontend filter/search logic