### PR TITLE
feat: redesign pending approval strip with field details and inline rejection input

### DIFF
--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -15,28 +15,23 @@ interface ComposerApprovalPromptProps {
   approval: AgentApproval;
   pendingCount: number;
   onResolved?: (decision: "approved" | "rejected") => void | Promise<void>;
-  onTellMeSomethingElse?: () => void;
+  onRejectedWithMessage?: (message: string) => void | Promise<void>;
 }
 
-/**
- * Compact approval strip anchored above the composer.
- *
- * Replaces the prior large inline approval card. Visually monochrome and
- * intentionally low-key so the surface reads as part of the composer rather
- * than a second chat bubble. Raw payload JSON is hidden behind a Details
- * disclosure that is closed by default.
- */
 export function ComposerApprovalPrompt({
   approval,
   pendingCount,
   onResolved,
-  onTellMeSomethingElse,
+  onRejectedWithMessage,
 }: ComposerApprovalPromptProps) {
   const [loading, setLoading] = useState(false);
   const [longExpanded, setLongExpanded] = useState<Record<string, boolean>>({});
+  const [inputMode, setInputMode] = useState(false);
+  const [inputText, setInputText] = useState("");
   // Ref-based lock so two clicks dispatched in the same React tick — before
   // `disabled={loading}` propagates — still cannot double-submit.
   const lockRef = useRef(false);
+  const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const summary = summarizeApproval(approval);
   const fields = extractApprovalFields(approval.proposedPayload);
   const olderPending = Math.max(0, pendingCount - 1);
@@ -46,8 +41,13 @@ export function ComposerApprovalPrompt({
   }
 
   async function handleCta(cta: ComposerCta) {
+    if (cta === "tell_me_something_else") {
+      setInputMode(true);
+      setTimeout(() => messageInputRef.current?.focus(), 0);
+      return;
+    }
     const decision = decisionForCta(cta);
-    const result = await runDecision({
+    await runDecision({
       approvalId: approval.id,
       decision,
       submit: submitApproval,
@@ -55,16 +55,21 @@ export function ComposerApprovalPrompt({
       setLoading,
       onResolved,
     });
-    // Only seed the composer / return focus when the rejection actually
-    // reached the backend. A skipped (already in-flight) or failed submit
-    // means the approval is still pending on the server, so behaving as if
-    // it had resolved would be misleading.
-    if (
-      cta === "tell_me_something_else" &&
-      result.status === "submitted" &&
-      result.decision === "rejected"
-    ) {
-      onTellMeSomethingElse?.();
+  }
+
+  async function handleMessageSubmit() {
+    const text = inputText.trim();
+    if (!text || loading) return;
+    const result = await runDecision({
+      approvalId: approval.id,
+      decision: "rejected",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+    });
+    if (result.status === "submitted") {
+      onRejectedWithMessage?.(text);
     }
   }
 
@@ -89,36 +94,6 @@ export function ComposerApprovalPrompt({
         {summary.detail && (
           <p className="truncate text-[11.5px] text-[#777777]">{summary.detail}</p>
         )}
-
-        <div className="flex flex-wrap items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => handleCta("yes")}
-            disabled={loading}
-            className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-3 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
-            style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-          >
-            Yes
-          </button>
-          <button
-            type="button"
-            onClick={() => handleCta("no")}
-            disabled={loading}
-            className="flex h-7 items-center rounded-[6px] border border-[#E0E0E0] px-3 text-[12px] font-medium text-[#333333] transition-colors hover:border-[#CFCFCF] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-            style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-          >
-            No
-          </button>
-          <button
-            type="button"
-            onClick={() => handleCta("tell_me_something_else")}
-            disabled={loading}
-            className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-            style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-          >
-            Tell me something else
-          </button>
-        </div>
 
         {fields.length > 0 && (
           <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
@@ -152,6 +127,79 @@ export function ComposerApprovalPrompt({
               );
             })}
           </dl>
+        )}
+
+        {inputMode ? (
+          <div className="flex flex-col gap-2">
+            <textarea
+              ref={messageInputRef}
+              value={inputText}
+              onChange={(e) => setInputText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleMessageSubmit();
+                }
+                if (e.key === "Escape") {
+                  setInputMode(false);
+                  setInputText("");
+                }
+              }}
+              placeholder="What should be different?"
+              rows={2}
+              disabled={loading}
+              className="w-full resize-none rounded-[6px] border border-[#E0E0E0] bg-[#FAFAFA] px-3 py-2 text-[12.5px] text-[#111111] placeholder-[#BBBBBB] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+            />
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleMessageSubmit}
+                disabled={loading || !inputText.trim()}
+                className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-3 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
+                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+              >
+                Send
+              </button>
+              <button
+                type="button"
+                onClick={() => { setInputMode(false); setInputText(""); }}
+                disabled={loading}
+                className="text-[11.5px] text-[#999999] transition-colors hover:text-[#555555] disabled:opacity-40"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => handleCta("yes")}
+              disabled={loading}
+              className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-3 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              Yes
+            </button>
+            <button
+              type="button"
+              onClick={() => handleCta("no")}
+              disabled={loading}
+              className="flex h-7 items-center rounded-[6px] border border-[#E0E0E0] px-3 text-[12px] font-medium text-[#333333] transition-colors hover:border-[#CFCFCF] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              No
+            </button>
+            <button
+              type="button"
+              onClick={() => handleCta("tell_me_something_else")}
+              disabled={loading}
+              className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              Tell me something else
+            </button>
+          </div>
         )}
       </div>
 

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from "react";
 import type { AgentApproval } from "./types";
-import { extractInnerPayload } from "./approvalPayload";
+import { extractApprovalFields } from "./approvalPayload";
 import { submitApproval } from "./adapters/runtime";
 import {
   decisionForCta,
@@ -33,12 +33,17 @@ export function ComposerApprovalPrompt({
   onTellMeSomethingElse,
 }: ComposerApprovalPromptProps) {
   const [loading, setLoading] = useState(false);
+  const [longExpanded, setLongExpanded] = useState<Record<string, boolean>>({});
   // Ref-based lock so two clicks dispatched in the same React tick — before
   // `disabled={loading}` propagates — still cannot double-submit.
   const lockRef = useRef(false);
   const summary = summarizeApproval(approval);
-  const inner = extractInnerPayload(approval.proposedPayload);
+  const fields = extractApprovalFields(approval.proposedPayload);
   const olderPending = Math.max(0, pendingCount - 1);
+
+  function toggleLong(key: string) {
+    setLongExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
 
   async function handleCta(cta: ComposerCta) {
     const decision = decisionForCta(cta);
@@ -115,16 +120,38 @@ export function ComposerApprovalPrompt({
           </button>
         </div>
 
-        {Object.keys(inner).length > 0 && (
-          <details className="group mt-0.5">
-            <summary className="flex cursor-pointer list-none items-center gap-1 text-[11px] font-medium text-[#999999] outline-none transition-colors hover:text-[#555555]">
-              <span className="inline-block transition-transform group-open:rotate-90">›</span>
-              Details
-            </summary>
-            <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-2.5 py-1.5 font-mono text-[10.5px] text-[#555555]">
-              {JSON.stringify(inner, null, 2)}
-            </pre>
-          </details>
+        {fields.length > 0 && (
+          <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
+            {fields.map((f) => {
+              const expanded = longExpanded[f.key] === true;
+              const clamped = f.isLong && f.displayValue.length > 200;
+              const shown =
+                clamped && !expanded
+                  ? f.displayValue.slice(0, 200).trimEnd() + "…"
+                  : f.displayValue;
+              return (
+                <div key={f.key} className="flex gap-3 py-1.5">
+                  <dt className="w-[110px] shrink-0 text-[11px] font-medium uppercase tracking-wide text-[#999999]">
+                    {f.label}
+                  </dt>
+                  <dd className="flex-1 text-[12px] leading-snug text-[#111111]">
+                    <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
+                      {shown}
+                    </span>
+                    {clamped && (
+                      <button
+                        type="button"
+                        onClick={() => toggleLong(f.key)}
+                        className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
+                      >
+                        {expanded ? "Show less" : "Show more"}
+                      </button>
+                    )}
+                  </dd>
+                </div>
+              );
+            })}
+          </dl>
         )}
       </div>
 

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -10,7 +10,6 @@ import { ResolvedApprovalCard } from "./ResolvedApprovalCard";
 import { ComposerApprovalPrompt } from "./ComposerApprovalPrompt";
 import { AgentInput, type AgentInputHandle } from "./AgentInput";
 import {
-  buildTellMeSomethingElseDraft,
   countPendingApprovals,
   getActiveComposerApproval,
 } from "./composerApproval";
@@ -467,12 +466,8 @@ export function ConversationTimeline({
             }
             onArtifactsChange?.();
           }}
-          onTellMeSomethingElse={() => {
-            // Preserve the existing draft if the user has already started
-            // typing; otherwise seed a short helper text so the composer is
-            // not empty when focus returns.
-            onDraftChange?.(buildTellMeSomethingElseDraft(draftValue ?? ""));
-            inputRef.current?.focus();
+          onRejectedWithMessage={(message) => {
+            handleSend(message);
           }}
         />
       )}


### PR DESCRIPTION
## Summary

- **Field details in pending approval**: replaces the raw JSON payload disclosure with a formatted field list (`extractApprovalFields`) showing human-readable labels, friendly values, and show more/less for long text
- **Yes · No button order**: flipped to Yes (primary/black) on the left, No (outline) on the right
- **"Tell me something else" → inline input**: clicking the ghost button no longer immediately rejects and seeds the main composer — instead it reveals an inline textarea above the CTA row; the user types their correction, presses Enter or Send, and the approval is rejected + a new run on the same thread starts automatically with that message
- **`ResolvedApprovalCard`** and **`ConversationTimeline`** timeline logic restored to match AGENTS.md contract (resolved approvals inline in chronological order, not grouped at top)

## Architecture notes

- No backend changes: rejection still `POST /api/agent/approvals/{id} { decision: "rejected" }`, follow-up message still `POST /api/agent/runs` on the same `thread_id`
- `composerApproval.ts` and its tests are untouched
- `onTellMeSomethingElse` prop removed from `ComposerApprovalPrompt`; replaced with `onRejectedWithMessage(message)` which `ConversationTimeline` wires to `handleSend`

## Test plan

- [ ] Trigger an approval-gated agent action (create/update event or book room)
- [ ] Verify approval strip shows field list with readable labels
- [ ] Verify button order is Yes · No · Tell me something else
- [ ] Click Yes → run resumes normally
- [ ] Click No → approval rejected, strip disappears
- [ ] Click Tell me something else → textarea appears, buttons hidden
- [ ] Type a message, press Enter → rejection fires, optimistic bubble appears, agent responds on same thread
- [ ] Press Escape or Cancel → returns to button view, no API call made
- [ ] Verify resolved approvals appear inline in timeline (not grouped at top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)