### PR TITLE
feat(outreach): implement send_outreach_email approval-gated tool

### DIFF
--- a/agent/apps/mcp/service.py
+++ b/agent/apps/mcp/service.py
@@ -652,11 +652,12 @@ async def send_outreach_email(
     recipient_email: str,
     subject: str,
     message_body: str,
-    sender_name: str,
-    sender_email: str,
+    sender_name: str = "",
+    sender_email: str = "",
     signature: str = "",
 ) -> dict:
     """Send an outreach email via AgentMail. Approval-gated — do not call unless the user has confirmed."""
+    import asyncio
     import os
 
     try:
@@ -665,15 +666,22 @@ async def send_outreach_email(
         from agent.helper.tools import get_agentmail_client  # type: ignore
 
     client = get_agentmail_client()
-    inbox_id = os.environ["AGENTMAIL_INBOX_ID"]
+    inbox_id = os.environ.get("AGENTMAIL_INBOX_ID")
+    if not inbox_id:
+        raise ValueError(
+            "AgentMail inbox is not configured. Set the AGENTMAIL_INBOX_ID environment "
+            "variable before calling send_outreach_email."
+        )
     full_body = f"{message_body}\n\n{signature}".strip() if signature else message_body
 
-    message = client.inboxes.messages.send(
-        inbox_id=inbox_id,
-        to=recipient_email,
-        subject=subject,
-        text=full_body,
-        labels=["outreach"],
+    message = await asyncio.to_thread(
+        lambda: client.inboxes.messages.send(
+            inbox_id=inbox_id,
+            to=recipient_email,
+            subject=subject,
+            text=full_body,
+            labels=["outreach"],
+        )
     )
     return {
         "sent": True,

--- a/agent/apps/mcp/service.py
+++ b/agent/apps/mcp/service.py
@@ -643,6 +643,46 @@ async def get_event_room_booking(event_id: str) -> dict | None:
         return await convex.get_event_room_booking(event_id)
 
 
+# ── Outreach email ────────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def send_outreach_email(
+    recipient_name: str,
+    recipient_email: str,
+    subject: str,
+    message_body: str,
+    sender_name: str,
+    sender_email: str,
+    signature: str = "",
+) -> dict:
+    """Send an outreach email via AgentMail. Approval-gated — do not call unless the user has confirmed."""
+    import os
+
+    try:
+        from helper.tools import get_agentmail_client
+    except ModuleNotFoundError:  # pragma: no cover - package import fallback
+        from agent.helper.tools import get_agentmail_client  # type: ignore
+
+    client = get_agentmail_client()
+    inbox_id = os.environ["AGENTMAIL_INBOX_ID"]
+    full_body = f"{message_body}\n\n{signature}".strip() if signature else message_body
+
+    message = client.inboxes.messages.send(
+        inbox_id=inbox_id,
+        to=recipient_email,
+        subject=subject,
+        text=full_body,
+        labels=["outreach"],
+    )
+    return {
+        "sent": True,
+        "thread_id": message.thread_id,
+        "recipient_email": recipient_email,
+        "subject": subject,
+    }
+
+
 __all__ = [
     "AttioClient",
     "ConvexClient",
@@ -675,4 +715,6 @@ __all__ = [
     "find_oncehub_slots",
     "book_oncehub_room",
     "get_event_room_booking",
+    # outreach email
+    "send_outreach_email",
 ]

--- a/agent/core/modal/config.py
+++ b/agent/core/modal/config.py
@@ -26,6 +26,7 @@ def build_image(*, extra_pip: Iterable[str] = (), add_prompts: bool = False) -> 
             "pydantic[email]>=2.0",
             "fastmcp>=2.0",
             "fastapi[standard]",
+            "agentmail",
             *list(extra_pip),
         )
         .add_local_python_source("helper", "runtime", "apps", "core")

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -21,6 +21,7 @@ from apps.mcp.service import (
     search_contacts,
     search_people,
     search_speakers,
+    send_outreach_email,
     update_event_safe,
     update_speaker_workflow,
     upsert_person,
@@ -54,6 +55,8 @@ __all__ = [
     "get_event_attendance",
     "create_event",
     "update_event_safe",
+    # outreach email
+    "send_outreach_email",
 ]
 
 

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -357,6 +357,26 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
             "required": ["event_id"],
         },
     },
+    {
+        "name": "send_outreach_email",
+        "description": (
+            "Send an outreach email to a recipient via AgentMail. "
+            "Approval-gated — the runtime will pause for explicit user approval before sending."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "recipient_name":  {"type": "string", "description": "Recipient's full name"},
+                "recipient_email": {"type": "string", "description": "Recipient's email address"},
+                "subject":         {"type": "string", "description": "Email subject line"},
+                "message_body":    {"type": "string", "description": "Main body of the email"},
+                "sender_name":     {"type": "string", "description": "Sender's display name (optional)"},
+                "sender_email":    {"type": "string", "description": "Sender's email address (optional)"},
+                "signature":       {"type": "string", "description": "Optional signature to append"},
+            },
+            "required": ["recipient_name", "recipient_email", "subject", "message_body"],
+        },
+    },
 ]
 
 

--- a/agent/runtime/policy.py
+++ b/agent/runtime/policy.py
@@ -89,6 +89,10 @@ WRITE_TOOL_NAMES = {
     "book_oncehub_room",
 }
 
+SEND_TOOL_NAMES = {
+    "send_outreach_email",
+}
+
 
 def infer_tool_action_from_tool_name(tool_name: str, payload: dict | None = None) -> ToolAction:
     normalized = tool_name.strip()
@@ -96,6 +100,8 @@ def infer_tool_action_from_tool_name(tool_name: str, payload: dict | None = None
         return ToolAction(name=normalized, action_class=ActionClass.READ, payload=payload or {})
     if normalized in WRITE_TOOL_NAMES:
         return ToolAction(name=normalized, action_class=ActionClass.WRITE, payload=payload or {})
+    if normalized in SEND_TOOL_NAMES:
+        return ToolAction(name=normalized, action_class=ActionClass.SEND, payload=payload or {})
 
     return ToolAction(name=normalized or "unknown_tool", action_class=ActionClass.ANALYZE, payload=payload or {})
 

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -102,6 +102,10 @@ def _make_approval_title(action: ToolAction) -> str:
         )
         base = f"Book Leslie eLab Lean/Launchpad: {title}"
         return f"{base} ({slot_label})" if slot_label else base
+    if action.name == "send_outreach_email":
+        name = tool_input.get("recipient_name") or tool_input.get("recipient_email", "contact")
+        subj = tool_input.get("subject", "")
+        return f"Send email to {name}" + (f": {subj}" if subj else "")
     return f"Approval required: {action.name}"
 
 

--- a/agent/runtime/tool_executor.py
+++ b/agent/runtime/tool_executor.py
@@ -22,6 +22,7 @@ try:
         search_contacts,
         search_people,
         search_speakers,
+        send_outreach_email,
         update_event_safe,
         update_speaker_workflow,
         upsert_person,
@@ -46,6 +47,7 @@ except ModuleNotFoundError:  # pragma: no cover - package import fallback
         search_contacts,
         search_people,
         search_speakers,
+        send_outreach_email,
         update_event_safe,
         update_speaker_workflow,
         upsert_person,
@@ -79,6 +81,8 @@ TOOL_HANDLERS: dict[str, ToolHandler] = {
     "find_oncehub_slots": find_oncehub_slots,
     "book_oncehub_room": book_oncehub_room,
     "get_event_room_booking": get_event_room_booking,
+    # outreach email
+    "send_outreach_email": send_outreach_email,
 }
 
 

--- a/agent/tests/test_mcp_server_io.py
+++ b/agent/tests/test_mcp_server_io.py
@@ -745,6 +745,92 @@ async def test_update_event_safe_io_with_event_type(monkeypatch: pytest.MonkeyPa
     assert updated == {"_id": "evt_10", "title": "Workshop", "event_type": "workshop"}
 
 
+# ── send_outreach_email tool body ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_outreach_email_calls_agentmail(monkeypatch: pytest.MonkeyPatch) -> None:
+    import helper.tools as helper_tools
+
+    class FakeMessage:
+        thread_id = "thread_abc"
+
+    sent_calls: list[dict] = []
+
+    class FakeMessages:
+        def send(self, *, inbox_id, to, subject, text, labels):
+            sent_calls.append(dict(inbox_id=inbox_id, to=to, subject=subject, text=text, labels=labels))
+            return FakeMessage()
+
+    class FakeInboxes:
+        messages = FakeMessages()
+
+    class FakeClient:
+        inboxes = FakeInboxes()
+
+    monkeypatch.setenv("AGENTMAIL_INBOX_ID", "inbox_test_1")
+    monkeypatch.setattr(helper_tools, "get_agentmail_client", lambda: FakeClient())
+
+    result = await mcp_service.send_outreach_email(
+        recipient_name="Ada Lovelace",
+        recipient_email="ada@example.com",
+        subject="Speaking invite",
+        message_body="Hi Ada, we'd love to have you.",
+        sender_name="NYU AI",
+        sender_email="ai@nyu.edu",
+        signature="Best,\nNYU AI Club",
+    )
+
+    assert result["sent"] is True
+    assert result["thread_id"] == "thread_abc"
+    assert result["recipient_email"] == "ada@example.com"
+    assert result["subject"] == "Speaking invite"
+    assert len(sent_calls) == 1
+    call = sent_calls[0]
+    assert call["inbox_id"] == "inbox_test_1"
+    assert call["to"] == "ada@example.com"
+    assert call["subject"] == "Speaking invite"
+    assert "Hi Ada" in call["text"]
+    assert "Best," in call["text"]
+    assert call["labels"] == ["outreach"]
+
+
+@pytest.mark.asyncio
+async def test_send_outreach_email_omits_signature_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    import helper.tools as helper_tools
+
+    class FakeMessage:
+        thread_id = "thread_no_sig"
+
+    sent_calls: list[dict] = []
+
+    class FakeMessages:
+        def send(self, *, inbox_id, to, subject, text, labels):
+            sent_calls.append(dict(text=text))
+            return FakeMessage()
+
+    class FakeInboxes:
+        messages = FakeMessages()
+
+    class FakeClient:
+        inboxes = FakeInboxes()
+
+    monkeypatch.setenv("AGENTMAIL_INBOX_ID", "inbox_test_2")
+    monkeypatch.setattr(helper_tools, "get_agentmail_client", lambda: FakeClient())
+
+    result = await mcp_service.send_outreach_email(
+        recipient_name="Bob",
+        recipient_email="bob@example.com",
+        subject="Hello",
+        message_body="Just a quick hello.",
+        sender_name="Alice",
+        sender_email="alice@example.com",
+    )
+
+    assert result["sent"] is True
+    assert sent_calls[0]["text"] == "Just a quick hello."
+
+
 def test_mcp_tool_docstrings_describe_event_and_attendance_uses() -> None:
     assert "newest relevant event" in (mcp_service.list_events.__doc__ or "")
     assert "actual attendance" in (mcp_service.get_event_attendance.__doc__ or "")

--- a/agent/tests/test_runtime_api.py
+++ b/agent/tests/test_runtime_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from runtime.api import build_app
+from runtime.convex_sync import ConvexAgentStateSync
 from runtime.service import AgentRuntimeService
 from runtime.store import InMemoryRuntimeStore
 
@@ -16,8 +17,32 @@ class FakeAdapter:
         yield "Done: response"
 
 
+class NullSync(ConvexAgentStateSync):
+    """Sync stub that never touches Convex — all writes are no-ops, all reads return None."""
+
+    async def upsert_thread(self, record): return None
+    async def upsert_run(self, record): return None
+    async def append_message(self, record): return None
+    async def upsert_artifact(self, record): return None
+    async def upsert_approval(self, record): return None
+    async def resolve_approval(self, record): return None
+    async def append_trace(self, record): return None
+    async def upsert_context_link(self, thread_external_id, record, run_external_id=None): return None
+    async def fetch_approval_thread_id(self, approval_external_id): return None
+    async def fetch_thread_state(self, external_thread_id): return None
+    async def fetch_threads(self, *, limit=50): return None
+
+
+def _make_service() -> AgentRuntimeService:
+    return AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=FakeAdapter(),
+        convex_sync=NullSync(),
+    )
+
+
 def test_runtime_api_agent_thread_run_stream_and_approval_flow() -> None:
-    service = AgentRuntimeService(store=InMemoryRuntimeStore(), adapter=FakeAdapter())
+    service = _make_service()
     app = build_app(service)
 
     client = TestClient(app)
@@ -63,7 +88,7 @@ def test_runtime_api_agent_thread_run_stream_and_approval_flow() -> None:
 
 
 def test_runtime_api_lists_agent_threads() -> None:
-    service = AgentRuntimeService(store=InMemoryRuntimeStore(), adapter=FakeAdapter())
+    service = _make_service()
     app = build_app(service)
 
     client = TestClient(app)

--- a/agent/tests/test_runtime_oncehub.py
+++ b/agent/tests/test_runtime_oncehub.py
@@ -216,6 +216,192 @@ async def test_approved_booking_attaches_event_context_link(monkeypatch: pytest.
     assert event_links[0].relation == "subject"
 
 
+# ── send_outreach_email approval title ────────────────────────────────────────
+
+
+def test_send_outreach_email_approval_title_with_name_and_subject() -> None:
+    action = ToolAction(
+        name="send_outreach_email",
+        action_class=ActionClass.SEND,
+        payload={
+            "tool_input": {
+                "recipient_name": "Ada Lovelace",
+                "recipient_email": "ada@example.com",
+                "subject": "Speaking invite",
+            }
+        },
+    )
+    assert _make_approval_title(action) == "Send email to Ada Lovelace: Speaking invite"
+
+
+def test_send_outreach_email_approval_title_falls_back_to_email() -> None:
+    action = ToolAction(
+        name="send_outreach_email",
+        action_class=ActionClass.SEND,
+        payload={"tool_input": {"recipient_email": "ada@example.com"}},
+    )
+    assert _make_approval_title(action) == "Send email to ada@example.com"
+
+
+def test_send_outreach_email_approval_title_no_subject() -> None:
+    action = ToolAction(
+        name="send_outreach_email",
+        action_class=ActionClass.SEND,
+        payload={"tool_input": {"recipient_name": "Ada Lovelace", "subject": ""}},
+    )
+    assert _make_approval_title(action) == "Send email to Ada Lovelace"
+
+
+# ── send_outreach_email approval flow ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_outreach_email_pauses_for_approval() -> None:
+    tool_input = {
+        "recipient_name": "Ada Lovelace",
+        "recipient_email": "ada@example.com",
+        "subject": "Speaking invite",
+        "message_body": "Hi Ada",
+        "sender_name": "NYU AI",
+        "sender_email": "ai@nyu.edu",
+    }
+    adapter = FakeToolAwareAdapter(
+        AgentTurnResult(
+            tool_traces=[
+                ToolTrace(name="send_outreach_email", tool_input=tool_input, tool_use_id="t1")
+            ],
+            blocked_action=ToolAction(
+                name="send_outreach_email",
+                action_class=ActionClass.SEND,
+                payload={"tool_input": tool_input},
+            ),
+        )
+    )
+    service = runtime_service.AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=adapter,
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Outreach email"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Send Ada a speaking invite")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    assert len(state.approvals) == 1
+    approval = state.approvals[0]
+    assert approval.status == ApprovalStatus.PENDING
+    assert approval.action_type == "send"
+    assert "Ada Lovelace" in approval.title
+    assert "Speaking invite" in approval.title
+
+
+@pytest.mark.asyncio
+async def test_approved_send_outreach_email_fires_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    fired = {"args": None}
+
+    async def fake_execute(tool_name: str, tool_input: dict):
+        assert tool_name == "send_outreach_email"
+        fired["args"] = tool_input
+        return {
+            "sent": True,
+            "thread_id": "thread_abc",
+            "recipient_email": tool_input["recipient_email"],
+            "subject": tool_input["subject"],
+        }
+
+    monkeypatch.setattr(runtime_service, "execute_tool_call", fake_execute)
+
+    tool_input = {
+        "recipient_name": "Ada Lovelace",
+        "recipient_email": "ada@example.com",
+        "subject": "Speaking invite",
+        "message_body": "Hi Ada",
+        "sender_name": "NYU AI",
+        "sender_email": "ai@nyu.edu",
+    }
+    adapter = FakeToolAwareAdapter(
+        AgentTurnResult(
+            tool_traces=[
+                ToolTrace(name="send_outreach_email", tool_input=tool_input, tool_use_id="t1")
+            ],
+            blocked_action=ToolAction(
+                name="send_outreach_email",
+                action_class=ActionClass.SEND,
+                payload={"tool_input": tool_input},
+            ),
+        )
+    )
+    service = runtime_service.AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=adapter,
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Outreach email approved"))
+    await service.start_run(
+        RunCreateRequest(thread_id=thread.external_id, input_text="Send Ada a speaking invite")
+    )
+
+    state = await service.get_thread_state(thread.external_id)
+    decision = await service.submit_approval(
+        state.approvals[0].external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.APPROVED),
+    )
+
+    assert decision.approval.status == ApprovalStatus.APPROVED
+    assert decision.run.status.value == "completed"
+    assert fired["args"] is not None
+    assert fired["args"]["recipient_email"] == "ada@example.com"
+
+
+@pytest.mark.asyncio
+async def test_rejected_send_outreach_email_does_not_fire_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"count": 0}
+
+    async def fake_execute(*_args, **_kwargs):
+        called["count"] += 1
+        return {}
+
+    monkeypatch.setattr(runtime_service, "execute_tool_call", fake_execute)
+
+    tool_input = {
+        "recipient_name": "Ada Lovelace",
+        "recipient_email": "ada@example.com",
+        "subject": "Speaking invite",
+        "message_body": "Hi Ada",
+        "sender_name": "NYU AI",
+        "sender_email": "ai@nyu.edu",
+    }
+    adapter = FakeToolAwareAdapter(
+        AgentTurnResult(
+            tool_traces=[ToolTrace(name="send_outreach_email", tool_input=tool_input, tool_use_id="t1")],
+            blocked_action=ToolAction(
+                name="send_outreach_email",
+                action_class=ActionClass.SEND,
+                payload={"tool_input": tool_input},
+            ),
+        )
+    )
+    service = runtime_service.AgentRuntimeService(
+        store=InMemoryRuntimeStore(),
+        adapter=adapter,
+        policy=ApprovalPolicy(),
+    )
+
+    thread = await service.create_thread(ThreadCreateRequest(title="Outreach email rejected"))
+    await service.start_run(RunCreateRequest(thread_id=thread.external_id, input_text="Send email"))
+    state = await service.get_thread_state(thread.external_id)
+    decision = await service.submit_approval(
+        state.approvals[0].external_id,
+        ApprovalDecisionRequest(decision=ApprovalStatus.REJECTED),
+    )
+
+    assert decision.approval.status == ApprovalStatus.REJECTED
+    assert called["count"] == 0
+
+
 @pytest.mark.asyncio
 async def test_rejected_booking_does_not_execute_tool(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {"count": 0}

--- a/agent/tests/test_runtime_policy.py
+++ b/agent/tests/test_runtime_policy.py
@@ -4,6 +4,7 @@ from runtime.policy import (
     ApprovalPolicy,
     ToolAction,
     infer_tool_action_from_text,
+    infer_tool_action_from_tool_name,
 )
 
 
@@ -35,3 +36,19 @@ def test_infer_tool_action_detects_send() -> None:
     action = infer_tool_action_from_text("Send an email update")
     assert action is not None
     assert action.action_class == ActionClass.SEND
+
+
+def test_infer_tool_action_from_tool_name_send_outreach_email() -> None:
+    action = infer_tool_action_from_tool_name(
+        "send_outreach_email",
+        payload={"tool_input": {"recipient_email": "ada@example.com"}},
+    )
+    assert action.action_class == ActionClass.SEND
+    assert action.name == "send_outreach_email"
+
+
+def test_send_outreach_email_requires_approval() -> None:
+    action = infer_tool_action_from_tool_name("send_outreach_email")
+    decision = ApprovalPolicy().evaluate(action)
+    assert decision.requires_approval
+    assert decision.risk_level == RiskLevel.MEDIUM


### PR DESCRIPTION
## Summary
- Adds `send_outreach_email` MCP tool to `apps/mcp/service.py` — calls AgentMail SDK with `AGENTMAIL_INBOX_ID`, tags emails with `["outreach"]` label, supports optional signature
- Wires the tool through `policy.py` (`SEND_TOOL_NAMES` → `ActionClass.SEND` → `requires_approval=True`), `tool_executor.py` (`TOOL_HANDLERS`), and `runtime/service.py` (`_make_approval_title` renders "Send email to {name}: {subject}")
- Adds `"agentmail"` to the base Modal image in `config.py` so the package is available without per-app `extra_pip`
- Fixes `test_runtime_api_lists_agent_threads`: introduced `NullSync` stub so both API tests are hermetic and don't leak real Convex threads when run under Doppler

## Test plan
- [x] `test_infer_tool_action_from_tool_name_send_outreach_email` — policy routes to `ActionClass.SEND`
- [x] `test_send_outreach_email_requires_approval` — policy decision is `requires_approval=True, risk_level=MEDIUM`
- [x] `test_send_outreach_email_approval_title_with_name_and_subject` — title renders correctly
- [x] `test_send_outreach_email_approval_title_falls_back_to_email` — falls back to email when no name
- [x] `test_send_outreach_email_approval_title_no_subject` — no trailing colon when subject is empty
- [x] `test_send_outreach_email_pauses_for_approval` — runtime pauses with `action_type=send`
- [x] `test_approved_send_outreach_email_fires_tool` — approved → tool body executes
- [x] `test_rejected_send_outreach_email_does_not_fire_tool` — rejected → tool never fires
- [x] `test_send_outreach_email_calls_agentmail` — tool body sends via fake AgentMail client with signature
- [x] `test_send_outreach_email_omits_signature_when_empty` — body is not padded when signature omitted
- [x] `test_runtime_api_lists_agent_threads` — now passes under Doppler env (was leaking live Convex threads)
- Full suite: **181 passed, 1 skipped** (only `test_attio.py::test_upsert_contact` skips without a live `ATTIO_API_KEY`, which is expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)