### PR TITLE
fix(agent): handle async run completion and artifact loading errors

### DIFF
--- a/fe+convex/app/agent/AgentShell.tsx
+++ b/fe+convex/app/agent/AgentShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQuery } from "convex/react";
@@ -41,11 +41,15 @@ interface AgentShellProps {
   activeThreadId: string | null;
 }
 
+type ViewState = { canvasOpen: boolean; draftValue: string; artifacts: AgentArtifact[] };
+
 export function AgentShell({ activeThreadId }: AgentShellProps) {
   const router = useRouter();
-  const [artifacts, setArtifacts] = useState<AgentArtifact[]>([]);
-  const [canvasOpen, setCanvasOpen] = useState(false);
-  const [draftValue, setDraftValue] = useState("");
+  const [{ canvasOpen, draftValue, artifacts }, dispatchView] = useReducer(
+    (s: ViewState, next: Partial<ViewState> | "reset"): ViewState =>
+      next === "reset" ? { canvasOpen: false, draftValue: "", artifacts: [] } : { ...s, ...next },
+    { canvasOpen: false, draftValue: "", artifacts: [] },
+  );
 
   // Same query ThreadRail uses — Convex deduplicates the subscription.
   const rawThreads = useQuery(api.agentState.listThreads, { limit: 50 });
@@ -63,16 +67,13 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
       : { id: activeThreadId, title: "Conversation", channel: "web", lastActivityAt: 0 };
   }, [activeThreadId, threadList]);
 
-  // Reset canvas and load artifacts whenever the active thread changes.
   useEffect(() => {
-    setCanvasOpen(false);
-    setDraftValue("");
-    setArtifacts([]);
+    dispatchView("reset");
     if (!activeThreadId) return;
     let cancelled = false;
     getThreadArtifacts(activeThreadId)
-      .then((arts) => { if (!cancelled) setArtifacts(arts); })
-      .catch(() => { /* thread may not be in Convex yet on first load */ });
+      .then((arts) => { if (!cancelled) dispatchView({ artifacts: arts }); })
+      .catch(() => {});
     return () => { cancelled = true; };
   }, [activeThreadId]);
 
@@ -80,8 +81,10 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
     async (threadId?: string) => {
       const resolvedId = threadId ?? activeThreadId;
       if (!resolvedId) return;
-      const arts = await getThreadArtifacts(resolvedId);
-      setArtifacts(arts);
+      try {
+        const arts = await getThreadArtifacts(resolvedId);
+        dispatchView({ artifacts: arts });
+      } catch {}
     },
     [activeThreadId],
   );
@@ -138,7 +141,7 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
           <div className="flex shrink-0 items-center gap-2">
             {artifacts.length > 0 && !canvasOpen && (
               <button
-                onClick={() => setCanvasOpen(true)}
+                onClick={() => dispatchView({ canvasOpen: true })}
                 className="rounded-[6px] border border-[#E0E0E0] px-2.5 py-1 text-[12px] font-medium text-[#555555] transition-colors duration-100 hover:bg-[#F4F4F4]"
               >
                 Artifacts ({artifacts.length})
@@ -162,11 +165,11 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
           }}
           emptyState={
             <AgentEmptyState
-              onPromptSelect={(prompt) => setDraftValue(prompt)}
+              onPromptSelect={(prompt) => dispatchView({ draftValue: prompt })}
             />
           }
           draftValue={draftValue}
-          onDraftChange={setDraftValue}
+          onDraftChange={(v) => dispatchView({ draftValue: v })}
         />
       </div>
 
@@ -177,7 +180,7 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
         >
           <ArtifactCanvas
             artifacts={artifacts}
-            onClose={() => setCanvasOpen(false)}
+            onClose={() => dispatchView({ canvasOpen: false })}
           />
         </div>
       )}

--- a/fe+convex/app/agent/AgentShell.tsx
+++ b/fe+convex/app/agent/AgentShell.tsx
@@ -70,9 +70,9 @@ export function AgentShell({ activeThreadId }: AgentShellProps) {
     setArtifacts([]);
     if (!activeThreadId) return;
     let cancelled = false;
-    getThreadArtifacts(activeThreadId).then((arts) => {
-      if (!cancelled) setArtifacts(arts);
-    });
+    getThreadArtifacts(activeThreadId)
+      .then((arts) => { if (!cancelled) setArtifacts(arts); })
+      .catch(() => { /* thread may not be in Convex yet on first load */ });
     return () => { cancelled = true; };
   }, [activeThreadId]);
 

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -240,14 +240,6 @@ export function ConversationTimeline({
 
     let active = true;
     startRun(threadId, pendingMsg)
-      .then(() => {
-        // Modal completed the run. Clear running state now so the UI
-        // doesn't hang if Convex is mis-pointed (e.g. wrong deployment).
-        if (active) {
-          setIsRunning(false);
-          onArtifactsChange?.(threadId);
-        }
-      })
       .catch(() => {
         if (active) {
           setIsRunning(false);
@@ -351,10 +343,6 @@ export function ConversationTimeline({
 
     try {
       await startRun(workingThread.id, text);
-      // Modal completed the run. Clear running state now so the UI doesn't
-      // hang if Convex is slow or pointed at the wrong deployment.
-      setIsRunning(false);
-      onArtifactsChange?.(workingThread.id);
     } catch {
       // If the run failed to start, clear all optimistic state so the UI
       // doesn't get stuck in a pending/thinking state with no response.

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -239,14 +239,23 @@ export function ConversationTimeline({
     setTracesVisible(true);
 
     let active = true;
-    startRun(threadId, pendingMsg).catch(() => {
-      if (active) {
-        setIsRunning(false);
-        setPendingMessage(null);
-        setTracesVisible(false);
-        runThreadIdRef.current = null;
-      }
-    });
+    startRun(threadId, pendingMsg)
+      .then(() => {
+        // Modal completed the run. Clear running state now so the UI
+        // doesn't hang if Convex is mis-pointed (e.g. wrong deployment).
+        if (active) {
+          setIsRunning(false);
+          onArtifactsChange?.(threadId);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setIsRunning(false);
+          setPendingMessage(null);
+          setTracesVisible(false);
+          runThreadIdRef.current = null;
+        }
+      });
     return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId]);
@@ -342,6 +351,10 @@ export function ConversationTimeline({
 
     try {
       await startRun(workingThread.id, text);
+      // Modal completed the run. Clear running state now so the UI doesn't
+      // hang if Convex is slow or pointed at the wrong deployment.
+      setIsRunning(false);
+      onArtifactsChange?.(workingThread.id);
     } catch {
       // If the run failed to start, clear all optimistic state so the UI
       // doesn't get stuck in a pending/thinking state with no response.
@@ -350,7 +363,6 @@ export function ConversationTimeline({
       setTracesVisible(false);
       runThreadIdRef.current = null;
     }
-    // isRunning is cleared reactively when the Convex run status changes.
   }
 
   const activeComposerApproval = getActiveComposerApproval(approvals);


### PR DESCRIPTION
## Summary

- **AgentShell**: Add `.catch()` to `getThreadArtifacts` promise so silent errors on first load (thread not yet in Convex) don't surface as unhandled rejections
- **ConversationTimeline**: Explicitly clear `isRunning` state in both the `useEffect`-triggered `startRun` path and the `handleSend` path after the run resolves, rather than relying solely on reactive Convex status updates — prevents the UI hanging in a pending/thinking state when Convex is slow or pointed at the wrong deployment
- Also calls `onArtifactsChange` after a successful run so the parent shell refreshes artifacts immediately

## Test plan

- [ ] Send a message in the agent view — confirm the loading indicator clears after the run completes
- [ ] Test with Convex pointed at a dev deployment that may lag — confirm UI doesn't hang
- [ ] Reload the page while a thread is selected — confirm no unhandled promise rejection in console
- [ ] Verify artifact panel refreshes automatically after a run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)