### PR TITLE
feat: email draft canvas + AgentMail outreach flow

### DIFF
--- a/agent/apps/mcp/modal_app.py
+++ b/agent/apps/mcp/modal_app.py
@@ -1,0 +1,35 @@
+"""Modal deployment for the event-organizer MCP server.
+
+Exposes all MCP tools (Attio, Convex, OnceHub, AgentMail) over streamable
+HTTP so the runtime adapter can reach them as a remote MCP endpoint.
+
+Deploy:
+    modal deploy agent/apps/mcp/modal_app.py
+
+The resulting endpoint URL should be set as MCP_SERVER_URL in the runtime
+environment (or NEXT_PUBLIC_MODAL_ENDPOINT for the frontend).
+"""
+from __future__ import annotations
+
+import modal
+
+try:
+    from core.modal.config import build_image, secret
+    from apps.mcp.service import mcp
+except ModuleNotFoundError:  # pragma: no cover - package import fallback
+    from agent.core.modal.config import build_image, secret  # type: ignore
+    from agent.apps.mcp.service import mcp  # type: ignore
+
+app = modal.App("event-mcp-server")
+
+image = build_image(extra_pip=["agentmail", "oncehub"])
+
+
+@app.function(
+    image=image,
+    secrets=[secret("mcp")],
+    timeout=300,
+)
+@modal.asgi_app()
+def mcp_asgi():
+    return mcp.streamable_http_app()

--- a/agent/apps/mcp/service.py
+++ b/agent/apps/mcp/service.py
@@ -34,6 +34,7 @@ try:
         normalize_speaker_source,
         normalize_speaker_status,
     )
+    from helper.tools import get_agentmail_client
 except ModuleNotFoundError:  # pragma: no cover - package import fallback
     from agent.core.clients.attio import (  # type: ignore
         AttioClient,
@@ -46,6 +47,7 @@ except ModuleNotFoundError:  # pragma: no cover - package import fallback
         normalize_speaker_source,
         normalize_speaker_status,
     )
+    from agent.helper.tools import get_agentmail_client  # type: ignore
 
 mcp = FastMCP("event-organizer")
 

--- a/agent/core/modal/config.py
+++ b/agent/core/modal/config.py
@@ -12,6 +12,7 @@ SECRETS = {
     "match": "doppler-v1",
     "outreach": "doppler-v1",
     "replies": "doppler-v1",
+    "mcp": "doppler-v1",
 }
 
 

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -3,9 +3,12 @@
 from apps.mcp.service import (
     AttioClient,
     ConvexClient,
+    OnceHubClient,
     append_person_note,
+    book_oncehub_room,
     create_event,
     ensure_speaker_for_person,
+    find_oncehub_slots,
     flatten_record,
     flatten_speaker_entry,
     get_attendance_dashboard,
@@ -14,6 +17,7 @@ from apps.mcp.service import (
     get_event_attendance,
     get_event_inbound_status,
     get_event_outreach,
+    get_event_room_booking,
     get_person,
     get_speaker,
     list_events,
@@ -30,6 +34,7 @@ from apps.mcp.service import (
 __all__ = [
     "AttioClient",
     "ConvexClient",
+    "OnceHubClient",
     "flatten_record",
     "flatten_speaker_entry",
     "mcp",
@@ -55,6 +60,10 @@ __all__ = [
     "get_event_attendance",
     "create_event",
     "update_event_safe",
+    # oncehub
+    "find_oncehub_slots",
+    "book_oncehub_room",
+    "get_event_room_booking",
     # outreach email
     "send_outreach_email",
 ]

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -40,9 +40,13 @@ DEFAULT_SYSTEM_PROMPT = (
     "Do not use internal field names (event_date, needs_outreach, event_time, etc.) when talking "
     "to the user — use natural language equivalents instead. "
     "When updating an event, confirm which fields will change before calling update_event_safe. "
-    "When the user asks to draft or send an outreach email, call `send_outreach_email` with all "
-    "required fields. The send is approval-gated — compose a complete draft and let the user "
-    "review before it is delivered."
+    "When the user asks to draft or send an outreach email: first call `get_event` (or "
+    "`list_events` if no event id is known) to retrieve the full event details — title, date, "
+    "time, location, description, and type. Also call `get_person` or `search_people` to confirm "
+    "the recipient's name and email. Then call `send_outreach_email` with all required fields "
+    "fully populated using those details. Never draft an email with placeholder or missing event "
+    "details. The send is approval-gated — compose a complete draft so the user can review the "
+    "full content before it is delivered."
 )
 DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -39,7 +39,10 @@ DEFAULT_SYSTEM_PROMPT = (
     "If no location is specified, default to '16 Washington Place'. "
     "Do not use internal field names (event_date, needs_outreach, event_time, etc.) when talking "
     "to the user — use natural language equivalents instead. "
-    "When updating an event, confirm which fields will change before calling update_event_safe."
+    "When updating an event, confirm which fields will change before calling update_event_safe. "
+    "When the user asks to draft or send an outreach email, call `send_outreach_email` with all "
+    "required fields. The send is approval-gated — compose a complete draft and let the user "
+    "review before it is delivered."
 )
 DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 
@@ -360,19 +363,20 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     {
         "name": "send_outreach_email",
         "description": (
-            "Send an outreach email to a recipient via AgentMail. "
-            "Approval-gated — the runtime will pause for explicit user approval before sending."
+            "Send a single outreach email via AgentMail. "
+            "Approval-gated: the user will review and can edit all fields before the email is sent. "
+            "Use this when the user asks to draft or send an email to a contact."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
-                "recipient_name":  {"type": "string", "description": "Recipient's full name"},
-                "recipient_email": {"type": "string", "description": "Recipient's email address"},
+                "recipient_name":  {"type": "string", "description": "Full name of the recipient"},
+                "recipient_email": {"type": "string", "description": "Recipient email address"},
                 "subject":         {"type": "string", "description": "Email subject line"},
-                "message_body":    {"type": "string", "description": "Main body of the email"},
-                "sender_name":     {"type": "string", "description": "Sender's display name (optional)"},
-                "sender_email":    {"type": "string", "description": "Sender's email address (optional)"},
-                "signature":       {"type": "string", "description": "Optional signature to append"},
+                "message_body":    {"type": "string", "description": "Main body of the email (without signature)"},
+                "sender_name":     {"type": "string", "description": "Display name of the sender (optional)"},
+                "sender_email":    {"type": "string", "description": "Sender email address (optional)"},
+                "signature":       {"type": "string", "description": "Email sign-off / signature block (optional)"},
             },
             "required": ["recipient_name", "recipient_email", "subject", "message_body"],
         },

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -45,8 +45,9 @@ DEFAULT_SYSTEM_PROMPT = (
     "time, location, description, and type. Also call `get_person` or `search_people` to confirm "
     "the recipient's name and email. Then call `send_outreach_email` with all required fields "
     "fully populated using those details. Never draft an email with placeholder or missing event "
-    "details. The send is approval-gated — compose a complete draft so the user can review the "
-    "full content before it is delivered."
+    "details. IMPORTANT: do NOT write the email content in your text response before or after "
+    "calling `send_outreach_email` — the approval UI will display the draft to the user. "
+    "Only call the tool; do not narrate or repeat the email body in chat."
 )
 DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -37,7 +37,7 @@ from .normalize import (
     summarize_text_for_thread,
     text_block,
 )
-from .policy import ApprovalPolicy, ToolAction, infer_tool_action_from_text
+from .policy import ActionClass, ApprovalPolicy, ToolAction, infer_tool_action_from_text
 from .store import InMemoryRuntimeStore
 from .tool_expectations import (
     RequestToolExpectation,
@@ -679,8 +679,12 @@ class AgentRuntimeService:
                     await self._maybe_emit_slot_table_artifact(run=run, tool_result=trace.result)
 
         if result.blocked_action:
-            # Finalize the streaming message before pausing
-            final_text = latest_text or "This action requires approval before execution."
+            # For send-class actions (email etc.) suppress any agent preamble text so
+            # the draft content only appears in the approval UI, not as a chat message.
+            if result.blocked_action.action_class == ActionClass.SEND:
+                final_text = ""
+            else:
+                final_text = latest_text or "This action requires approval before execution."
             await self._patch_streaming_assistant_message(
                 assistant_msg, final_text, status="final"
             )

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -459,7 +459,7 @@ class AgentRuntimeService:
             thread_external_id=run.thread_external_id,
             run_external_id=run.external_id,
             status=ApprovalStatus.PENDING,
-            action_type=action.action_class.value,
+            action_type=action.name,
             title=_make_approval_title(action),
             summary=decision.reason,
             risk_level=decision.risk_level,

--- a/agent/runtime/tool_expectations.py
+++ b/agent/runtime/tool_expectations.py
@@ -76,7 +76,23 @@ def infer_request_tool_expectation(text: str) -> RequestToolExpectation | None:
             no_data_message="I couldn't find any events in Convex to report on.",
         )
 
-    if "outreach" in lowered or "inbound" in lowered:
+    if _mentions_any(lowered, ("send", "draft", "write", "compose")) and _mentions_any(
+        lowered, ("email", "mail", "message")
+    ):
+        return RequestToolExpectation(
+            kind="send_email",
+            relevant_tools=("send_outreach_email",),
+            retry_instruction=(
+                "The user wants to send or draft an email. Call `send_outreach_email` with all "
+                "required fields. Fetch event details with `get_event` or `list_events` and "
+                "recipient info with `search_people` or `get_person` first if needed, then call "
+                "`send_outreach_email`. Do not just write the email as text."
+            ),
+        )
+
+    if ("outreach" in lowered or "inbound" in lowered) and not _mentions_any(
+        lowered, ("send", "draft", "write", "compose", "email", "mail")
+    ):
         return RequestToolExpectation(
             kind="event_outreach",
             relevant_tools=("get_event_outreach", "get_event_inbound_status", "list_events"),

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { AgentApproval } from "./types";
 import { extractApprovalFields, extractInnerPayload } from "./approvalPayload";
 import { submitApproval } from "./adapters/runtime";
@@ -136,8 +138,11 @@ export function ComposerApprovalPrompt({
         {fields.length > 0 && !editMode && (
           <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
             {fields.map((f) => {
+              const isRichField = isEmailApproval && f.key === "message_body";
+              // For email body fields always show full content; clamp others as before
+              const neverClamp = isEmailApproval && (f.key === "message_body" || f.key === "signature");
               const expanded = longExpanded[f.key] === true;
-              const clamped = f.isLong && f.displayValue.length > 200;
+              const clamped = !neverClamp && f.isLong && f.displayValue.length > 200;
               const shown =
                 clamped && !expanded
                   ? f.displayValue.slice(0, 200).trimEnd() + "…"
@@ -148,17 +153,27 @@ export function ComposerApprovalPrompt({
                     {f.label}
                   </dt>
                   <dd className="flex-1 text-[12px] leading-snug text-[#111111]">
-                    <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
-                      {shown}
-                    </span>
-                    {clamped && (
-                      <button
-                        type="button"
-                        onClick={() => toggleLong(f.key)}
-                        className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
-                      >
-                        {expanded ? "Show less" : "Show more"}
-                      </button>
+                    {isRichField ? (
+                      <div className="break-words [&_strong]:font-semibold [&_em]:italic [&_u]:underline [&_p]:mb-1.5 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:mb-0.5">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {f.displayValue}
+                        </ReactMarkdown>
+                      </div>
+                    ) : (
+                      <>
+                        <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
+                          {shown}
+                        </span>
+                        {clamped && (
+                          <button
+                            type="button"
+                            onClick={() => toggleLong(f.key)}
+                            className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
+                          >
+                            {expanded ? "Show less" : "Show more"}
+                          </button>
+                        )}
+                      </>
                     )}
                   </dd>
                 </div>

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from "react";
 import type { AgentApproval } from "./types";
-import { extractApprovalFields } from "./approvalPayload";
+import { extractApprovalFields, extractInnerPayload } from "./approvalPayload";
 import { submitApproval } from "./adapters/runtime";
 import {
   decisionForCta,
@@ -18,6 +18,16 @@ interface ComposerApprovalPromptProps {
   onRejectedWithMessage?: (message: string) => void | Promise<void>;
 }
 
+const EMAIL_FIELDS: { key: string; label: string; multiline: boolean; rows?: number }[] = [
+  { key: "recipient_name", label: "Recipient", multiline: false },
+  { key: "recipient_email", label: "To", multiline: false },
+  { key: "subject", label: "Subject", multiline: false },
+  { key: "sender_name", label: "From", multiline: false },
+  { key: "sender_email", label: "Sender Email", multiline: false },
+  { key: "message_body", label: "Message", multiline: true, rows: 6 },
+  { key: "signature", label: "Signature", multiline: true, rows: 2 },
+];
+
 export function ComposerApprovalPrompt({
   approval,
   pendingCount,
@@ -28,6 +38,8 @@ export function ComposerApprovalPrompt({
   const [longExpanded, setLongExpanded] = useState<Record<string, boolean>>({});
   const [inputMode, setInputMode] = useState(false);
   const [inputText, setInputText] = useState("");
+  const [editMode, setEditMode] = useState(false);
+  const [editFields, setEditFields] = useState<Record<string, string>>({});
   // Ref-based lock so two clicks dispatched in the same React tick — before
   // `disabled={loading}` propagates — still cannot double-submit.
   const lockRef = useRef(false);
@@ -35,9 +47,21 @@ export function ComposerApprovalPrompt({
   const summary = summarizeApproval(approval);
   const fields = extractApprovalFields(approval.proposedPayload);
   const olderPending = Math.max(0, pendingCount - 1);
+  const isEmailApproval = approval.actionType === "send_outreach_email";
 
   function toggleLong(key: string) {
     setLongExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  function enterEditMode() {
+    const inner = extractInnerPayload(approval.proposedPayload);
+    const initial: Record<string, string> = {};
+    for (const { key } of EMAIL_FIELDS) {
+      const val = inner[key];
+      initial[key] = val !== null && val !== undefined ? String(val) : "";
+    }
+    setEditFields(initial);
+    setEditMode(true);
   }
 
   async function handleCta(cta: ComposerCta) {
@@ -73,6 +97,19 @@ export function ComposerApprovalPrompt({
     }
   }
 
+  async function handleEditConfirm() {
+    if (loading) return;
+    await runDecision({
+      approvalId: approval.id,
+      decision: "approved",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+      overrideArgs: editFields,
+    });
+  }
+
   return (
     <div
       className="shrink-0 border-t border-[#EBEBEB] bg-[#FFFFFF]"
@@ -95,7 +132,8 @@ export function ComposerApprovalPrompt({
           <p className="truncate text-[11.5px] text-[#777777]">{summary.detail}</p>
         )}
 
-        {fields.length > 0 && (
+        {/* Field list — hidden in edit mode to avoid duplication */}
+        {fields.length > 0 && !editMode && (
           <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
             {fields.map((f) => {
               const expanded = longExpanded[f.key] === true;
@@ -129,7 +167,56 @@ export function ComposerApprovalPrompt({
           </dl>
         )}
 
-        {inputMode ? (
+        {/* Edit canvas — email fields */}
+        {editMode ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1.5 rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-2">
+              {EMAIL_FIELDS.map(({ key, label, multiline, rows }) => (
+                <div key={key} className="flex flex-col gap-0.5">
+                  <label className="text-[10.5px] font-medium uppercase tracking-wide text-[#999999]">
+                    {label}
+                  </label>
+                  {multiline ? (
+                    <textarea
+                      value={editFields[key] ?? ""}
+                      onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
+                      rows={rows ?? 2}
+                      disabled={loading}
+                      className="w-full resize-none rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] leading-snug text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+                    />
+                  ) : (
+                    <input
+                      type="text"
+                      value={editFields[key] ?? ""}
+                      onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
+                      disabled={loading}
+                      className="w-full rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleEditConfirm}
+                disabled={loading}
+                className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-3 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
+                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                onClick={() => { setEditMode(false); setEditFields({}); }}
+                disabled={loading}
+                className="text-[11.5px] text-[#999999] transition-colors hover:text-[#555555] disabled:opacity-40"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : inputMode ? (
           <div className="flex flex-col gap-2">
             <textarea
               ref={messageInputRef}
@@ -190,15 +277,27 @@ export function ComposerApprovalPrompt({
             >
               No
             </button>
-            <button
-              type="button"
-              onClick={() => handleCta("tell_me_something_else")}
-              disabled={loading}
-              className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-            >
-              Tell me something else
-            </button>
+            {isEmailApproval ? (
+              <button
+                type="button"
+                onClick={enterEditMode}
+                disabled={loading}
+                className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+              >
+                Edit
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => handleCta("tell_me_something_else")}
+                disabled={loading}
+                className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+              >
+                Tell me something else
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -25,6 +25,7 @@ export function ComposerApprovalPrompt({
   onResolved,
   onRejectedWithMessage,
 }: ComposerApprovalPromptProps) {
+  console.log("[ApprovalPrompt] actionType =", approval.actionType, "| requestedAction =", approval.requestedAction);
   if (approval.actionType === "send_outreach_email") {
     return (
       <EmailDraftCanvas
@@ -53,7 +54,6 @@ function GenericApprovalPrompt({
   onRejectedWithMessage,
 }: ComposerApprovalPromptProps) {
   const [loading, setLoading] = useState(false);
-  const [longExpanded, setLongExpanded] = useState<Record<string, boolean>>({});
   const [inputMode, setInputMode] = useState(false);
   const [inputText, setInputText] = useState("");
   const lockRef = useRef(false);
@@ -62,10 +62,6 @@ function GenericApprovalPrompt({
   const summary = summarizeApproval(approval);
   const fields = extractApprovalFields(approval.proposedPayload);
   const olderPending = Math.max(0, pendingCount - 1);
-
-  function toggleLong(key: string) {
-    setLongExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
-  }
 
   async function handleCta(cta: ComposerCta) {
     if (cta === "tell_me_something_else") {
@@ -123,37 +119,18 @@ function GenericApprovalPrompt({
         )}
 
         {fields.length > 0 && (
-          <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
-            {fields.map((f) => {
-              const expanded = longExpanded[f.key] === true;
-              const clamped = f.isLong && f.displayValue.length > 200;
-              const shown =
-                clamped && !expanded
-                  ? f.displayValue.slice(0, 200).trimEnd() + "…"
-                  : f.displayValue;
-              return (
-                <div key={f.key} className="flex gap-3 py-1.5">
-                  <dt className="w-[110px] shrink-0 text-[11px] font-medium uppercase tracking-wide text-[#999999]">
-                    {f.label}
-                  </dt>
-                  <dd className="flex-1 text-[12px] leading-snug text-[#111111]">
-                    <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
-                      {shown}
-                    </span>
-                    {clamped && (
-                      <button
-                        type="button"
-                        onClick={() => toggleLong(f.key)}
-                        className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
-                      >
-                        {expanded ? "Show less" : "Show more"}
-                      </button>
-                    )}
-                  </dd>
-                </div>
-              );
-            })}
-          </dl>
+          <div className="mt-1 flex flex-col gap-1.5 rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-2">
+            {fields.map((f) => (
+              <div key={f.key} className="flex flex-col gap-0.5">
+                <span className="text-[10.5px] font-semibold uppercase tracking-wide text-[#AAAAAA]">
+                  {f.label}
+                </span>
+                <span className="whitespace-pre-wrap break-words text-[12.5px] leading-snug text-[#111111]">
+                  {f.displayValue}
+                </span>
+              </div>
+            ))}
+          </div>
         )}
 
         {inputMode ? (

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { AgentApproval } from "./types";
-import { extractApprovalFields, extractInnerPayload } from "./approvalPayload";
+import { extractApprovalFields } from "./approvalPayload";
 import { submitApproval } from "./adapters/runtime";
 import {
   decisionForCta,
@@ -12,6 +10,7 @@ import {
   summarizeApproval,
   type ComposerCta,
 } from "./composerApproval";
+import { EmailDraftCanvas } from "./EmailDraftCanvas";
 
 interface ComposerApprovalPromptProps {
   approval: AgentApproval;
@@ -20,17 +19,34 @@ interface ComposerApprovalPromptProps {
   onRejectedWithMessage?: (message: string) => void | Promise<void>;
 }
 
-const EMAIL_FIELDS: { key: string; label: string; multiline: boolean; rows?: number }[] = [
-  { key: "recipient_name", label: "Recipient", multiline: false },
-  { key: "recipient_email", label: "To", multiline: false },
-  { key: "subject", label: "Subject", multiline: false },
-  { key: "sender_name", label: "From", multiline: false },
-  { key: "sender_email", label: "Sender Email", multiline: false },
-  { key: "message_body", label: "Message", multiline: true, rows: 6 },
-  { key: "signature", label: "Signature", multiline: true, rows: 2 },
-];
-
 export function ComposerApprovalPrompt({
+  approval,
+  pendingCount,
+  onResolved,
+  onRejectedWithMessage,
+}: ComposerApprovalPromptProps) {
+  if (approval.actionType === "send_outreach_email") {
+    return (
+      <EmailDraftCanvas
+        approval={approval}
+        pendingCount={pendingCount}
+        onResolved={onResolved}
+        onRejectedWithMessage={onRejectedWithMessage}
+      />
+    );
+  }
+
+  return (
+    <GenericApprovalPrompt
+      approval={approval}
+      pendingCount={pendingCount}
+      onResolved={onResolved}
+      onRejectedWithMessage={onRejectedWithMessage}
+    />
+  );
+}
+
+function GenericApprovalPrompt({
   approval,
   pendingCount,
   onResolved,
@@ -40,30 +56,15 @@ export function ComposerApprovalPrompt({
   const [longExpanded, setLongExpanded] = useState<Record<string, boolean>>({});
   const [inputMode, setInputMode] = useState(false);
   const [inputText, setInputText] = useState("");
-  const [editMode, setEditMode] = useState(false);
-  const [editFields, setEditFields] = useState<Record<string, string>>({});
-  // Ref-based lock so two clicks dispatched in the same React tick — before
-  // `disabled={loading}` propagates — still cannot double-submit.
   const lockRef = useRef(false);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
+
   const summary = summarizeApproval(approval);
   const fields = extractApprovalFields(approval.proposedPayload);
   const olderPending = Math.max(0, pendingCount - 1);
-  const isEmailApproval = approval.actionType === "send_outreach_email";
 
   function toggleLong(key: string) {
     setLongExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
-  }
-
-  function enterEditMode() {
-    const inner = extractInnerPayload(approval.proposedPayload);
-    const initial: Record<string, string> = {};
-    for (const { key } of EMAIL_FIELDS) {
-      const val = inner[key];
-      initial[key] = val !== null && val !== undefined ? String(val) : "";
-    }
-    setEditFields(initial);
-    setEditMode(true);
   }
 
   async function handleCta(cta: ComposerCta) {
@@ -99,19 +100,6 @@ export function ComposerApprovalPrompt({
     }
   }
 
-  async function handleEditConfirm() {
-    if (loading) return;
-    await runDecision({
-      approvalId: approval.id,
-      decision: "approved",
-      submit: submitApproval,
-      lock: lockRef,
-      setLoading,
-      onResolved,
-      overrideArgs: editFields,
-    });
-  }
-
   return (
     <div
       className="shrink-0 border-t border-[#EBEBEB] bg-[#FFFFFF]"
@@ -134,15 +122,11 @@ export function ComposerApprovalPrompt({
           <p className="truncate text-[11.5px] text-[#777777]">{summary.detail}</p>
         )}
 
-        {/* Field list — hidden in edit mode to avoid duplication */}
-        {fields.length > 0 && !editMode && (
+        {fields.length > 0 && (
           <dl className="mt-1 divide-y divide-[#F1F1F1] rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-1">
             {fields.map((f) => {
-              const isRichField = isEmailApproval && f.key === "message_body";
-              // For email body fields always show full content; clamp others as before
-              const neverClamp = isEmailApproval && (f.key === "message_body" || f.key === "signature");
               const expanded = longExpanded[f.key] === true;
-              const clamped = !neverClamp && f.isLong && f.displayValue.length > 200;
+              const clamped = f.isLong && f.displayValue.length > 200;
               const shown =
                 clamped && !expanded
                   ? f.displayValue.slice(0, 200).trimEnd() + "…"
@@ -153,27 +137,17 @@ export function ComposerApprovalPrompt({
                     {f.label}
                   </dt>
                   <dd className="flex-1 text-[12px] leading-snug text-[#111111]">
-                    {isRichField ? (
-                      <div className="break-words [&_strong]:font-semibold [&_em]:italic [&_u]:underline [&_p]:mb-1.5 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:mb-0.5">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {f.displayValue}
-                        </ReactMarkdown>
-                      </div>
-                    ) : (
-                      <>
-                        <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
-                          {shown}
-                        </span>
-                        {clamped && (
-                          <button
-                            type="button"
-                            onClick={() => toggleLong(f.key)}
-                            className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
-                          >
-                            {expanded ? "Show less" : "Show more"}
-                          </button>
-                        )}
-                      </>
+                    <span className={f.isLong ? "whitespace-pre-wrap break-words" : "break-words"}>
+                      {shown}
+                    </span>
+                    {clamped && (
+                      <button
+                        type="button"
+                        onClick={() => toggleLong(f.key)}
+                        className="ml-2 text-[11px] font-medium text-[#555555] underline-offset-2 hover:underline"
+                      >
+                        {expanded ? "Show less" : "Show more"}
+                      </button>
                     )}
                   </dd>
                 </div>
@@ -182,56 +156,7 @@ export function ComposerApprovalPrompt({
           </dl>
         )}
 
-        {/* Edit canvas — email fields */}
-        {editMode ? (
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col gap-1.5 rounded-[6px] border border-[#EBEBEB] bg-[#FAFAFA] px-3 py-2">
-              {EMAIL_FIELDS.map(({ key, label, multiline, rows }) => (
-                <div key={key} className="flex flex-col gap-0.5">
-                  <label className="text-[10.5px] font-medium uppercase tracking-wide text-[#999999]">
-                    {label}
-                  </label>
-                  {multiline ? (
-                    <textarea
-                      value={editFields[key] ?? ""}
-                      onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
-                      rows={rows ?? 2}
-                      disabled={loading}
-                      className="w-full resize-none rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] leading-snug text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
-                    />
-                  ) : (
-                    <input
-                      type="text"
-                      value={editFields[key] ?? ""}
-                      onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
-                      disabled={loading}
-                      className="w-full rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
-                    />
-                  )}
-                </div>
-              ))}
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={handleEditConfirm}
-                disabled={loading}
-                className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-3 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
-                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-              >
-                Confirm
-              </button>
-              <button
-                type="button"
-                onClick={() => { setEditMode(false); setEditFields({}); }}
-                disabled={loading}
-                className="text-[11.5px] text-[#999999] transition-colors hover:text-[#555555] disabled:opacity-40"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        ) : inputMode ? (
+        {inputMode ? (
           <div className="flex flex-col gap-2">
             <textarea
               ref={messageInputRef}
@@ -292,27 +217,15 @@ export function ComposerApprovalPrompt({
             >
               No
             </button>
-            {isEmailApproval ? (
-              <button
-                type="button"
-                onClick={enterEditMode}
-                disabled={loading}
-                className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-              >
-                Edit
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => handleCta("tell_me_something_else")}
-                disabled={loading}
-                className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-                style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
-              >
-                Tell me something else
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => handleCta("tell_me_something_else")}
+              disabled={loading}
+              className="flex h-7 items-center rounded-[6px] border border-transparent px-2 text-[12px] font-medium text-[#555555] transition-colors hover:border-[#E0E0E0] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              Tell me something else
+            </button>
           </div>
         )}
       </div>

--- a/fe+convex/components/agent/ComposerApprovalPrompt.tsx
+++ b/fe+convex/components/agent/ComposerApprovalPrompt.tsx
@@ -26,7 +26,15 @@ export function ComposerApprovalPrompt({
   onRejectedWithMessage,
 }: ComposerApprovalPromptProps) {
   console.log("[ApprovalPrompt] actionType =", approval.actionType, "| requestedAction =", approval.requestedAction);
-  if (approval.actionType === "send_outreach_email") {
+  const lowerAction = (approval.actionType ?? "").toLowerCase();
+  const lowerTitle = (approval.requestedAction ?? "").toLowerCase();
+  const isEmailApproval =
+    lowerAction.includes("email") ||
+    lowerAction.includes("mail") ||
+    lowerTitle.includes("email") ||
+    lowerTitle.includes("send email") ||
+    lowerTitle.includes("draft email");
+  if (isEmailApproval) {
     return (
       <EmailDraftCanvas
         approval={approval}

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -60,6 +60,7 @@ type ConvexApproval = {
   status: string;
   risk_level: string;
   requested_at: number;
+  action_type?: string;
 };
 
 type ConvexTrace = {
@@ -116,6 +117,7 @@ function mapConvexApproval(a: ConvexApproval): AgentApproval {
     proposedPayload,
     status: a.status as AgentApproval["status"],
     createdAt: a.requested_at,
+    actionType: a.action_type,
   };
 }
 

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -177,7 +177,9 @@ export function ConversationTimeline({
 
   // Derive messages, approvals, and traces from the reactive query result.
   const messages: AgentMessage[] = threadState
-    ? (threadState.messages as unknown as ConvexMessage[]).map(mapConvexMessage)
+    ? (threadState.messages as unknown as ConvexMessage[])
+        .map(mapConvexMessage)
+        .filter((m) => m.content.some((b) => b.type === "text" && b.text.trim() !== ""))
     : [];
 
   const approvals: AgentApproval[] = threadState

--- a/fe+convex/components/agent/EmailDraftCanvas.tsx
+++ b/fe+convex/components/agent/EmailDraftCanvas.tsx
@@ -1,0 +1,436 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { AgentApproval } from "./types";
+import { extractInnerPayload } from "./approvalPayload";
+import { submitApproval } from "./adapters/runtime";
+import { runDecision } from "./composerApproval";
+
+interface EmailDraftCanvasProps {
+  approval: AgentApproval;
+  pendingCount: number;
+  onResolved?: (decision: "approved" | "rejected") => void | Promise<void>;
+  onRejectedWithMessage?: (message: string) => void | Promise<void>;
+}
+
+interface EmailFields {
+  recipient_name: string;
+  recipient_email: string;
+  subject: string;
+  message_body: string;
+  sender_name: string;
+  sender_email: string;
+  signature: string;
+}
+
+function readEmailFields(approval: AgentApproval): EmailFields {
+  const inner = extractInnerPayload(approval.proposedPayload);
+  const get = (k: keyof EmailFields) => {
+    const v = inner[k];
+    return v !== null && v !== undefined ? String(v) : "";
+  };
+  return {
+    recipient_name: get("recipient_name"),
+    recipient_email: get("recipient_email"),
+    subject: get("subject"),
+    message_body: get("message_body"),
+    sender_name: get("sender_name"),
+    sender_email: get("sender_email"),
+    signature: get("signature"),
+  };
+}
+
+export function EmailDraftCanvas({
+  approval,
+  pendingCount,
+  onResolved,
+  onRejectedWithMessage,
+}: EmailDraftCanvasProps) {
+  const [fields, setFields] = useState<EmailFields>(() => readEmailFields(approval));
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [selectionText, setSelectionText] = useState<string | null>(null);
+  const [askInput, setAskInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const lockRef = useRef(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const askInputRef = useRef<HTMLInputElement>(null);
+
+  // Re-seed when a new approval lands (e.g. after a partial-revision round-trip).
+  useEffect(() => {
+    setFields(readEmailFields(approval));
+    setMode("view");
+    setSelectionText(null);
+    setAskInput("");
+  }, [approval.id, approval.proposedPayload]);
+
+  useEffect(() => {
+    if (selectionText) askInputRef.current?.focus();
+  }, [selectionText]);
+
+  const olderPending = Math.max(0, pendingCount - 1);
+
+  function captureSelection() {
+    if (mode !== "view") return;
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !bodyRef.current) {
+      setSelectionText(null);
+      return;
+    }
+    const anchor = sel.anchorNode;
+    const focus = sel.focusNode;
+    const within =
+      (anchor && bodyRef.current.contains(anchor)) ||
+      (focus && bodyRef.current.contains(focus));
+    if (!within) {
+      setSelectionText(null);
+      return;
+    }
+    const text = sel.toString().trim();
+    if (!text) {
+      setSelectionText(null);
+      return;
+    }
+    setSelectionText(text);
+  }
+
+  async function handleSend() {
+    if (loading) return;
+    await runDecision({
+      approvalId: approval.id,
+      decision: "approved",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+      overrideArgs: fields,
+    });
+  }
+
+  async function handleCopy() {
+    const text = `Subject: ${fields.subject}\n\n${fields.message_body}${fields.signature ? `\n\n${fields.signature}` : ""}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // best-effort; ignore
+    }
+  }
+
+  async function handleAskForChanges() {
+    const passage = (selectionText ?? "").trim();
+    const instruction = askInput.trim();
+    if (!passage || !instruction || loading) return;
+
+    const message = [
+      "Please revise the highlighted passage in the email body and re-issue the send_outreach_email approval.",
+      `Highlighted passage: """${passage}"""`,
+      `Change requested: ${instruction}`,
+      "Keep the rest of the email body unchanged. Preserve the existing recipient, sender, and subject unless the change instruction implies otherwise.",
+    ].join("\n");
+
+    const result = await runDecision({
+      approvalId: approval.id,
+      decision: "rejected",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+    });
+    if (result.status === "submitted") {
+      setSelectionText(null);
+      setAskInput("");
+      onRejectedWithMessage?.(message);
+    }
+  }
+
+  function updateField<K extends keyof EmailFields>(key: K, value: string) {
+    setFields((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <div
+      className="shrink-0 border-t border-[#EBEBEB] bg-[#FFFFFF]"
+      style={{ animation: "emailCanvasIn 160ms cubic-bezier(0.23, 1, 0.32, 1) both" }}
+      role="region"
+      aria-label="Email draft"
+    >
+      <div className="flex flex-col gap-2 px-4 pt-3 pb-3">
+        {olderPending > 0 && (
+          <div className="flex justify-end">
+            <span className="text-[11px] text-[#999999]">+{olderPending} more pending</span>
+          </div>
+        )}
+
+        <div className="rounded-[10px] border border-[#EBEBEB] bg-[#FAFAFA]">
+          {/* Top bar */}
+          <div className="flex items-center justify-between gap-2 border-b border-[#EBEBEB] px-3 py-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              {selectionText && mode === "view" ? (
+                <div className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[999px] border border-[#E0E0E0] bg-[#FFFFFF] px-2.5 py-1">
+                  <PencilIcon className="h-3 w-3 shrink-0 text-[#777777]" />
+                  <input
+                    ref={askInputRef}
+                    type="text"
+                    value={askInput}
+                    onChange={(e) => setAskInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && askInput.trim()) {
+                        e.preventDefault();
+                        handleAskForChanges();
+                      }
+                      if (e.key === "Escape") {
+                        setSelectionText(null);
+                        setAskInput("");
+                      }
+                    }}
+                    placeholder="Ask for changes"
+                    disabled={loading}
+                    className="w-full bg-transparent text-[12px] text-[#111111] placeholder-[#BBBBBB] outline-none disabled:opacity-40"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAskForChanges}
+                    disabled={loading || !askInput.trim()}
+                    aria-label="Send changes"
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A] text-white transition-opacity hover:opacity-90 disabled:opacity-30"
+                  >
+                    <ArrowUpIcon className="h-3 w-3" />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setMode((m) => (m === "edit" ? "view" : "edit"))}
+                  disabled={loading}
+                  className="inline-flex items-center gap-1.5 rounded-[999px] border border-[#E0E0E0] bg-[#FFFFFF] px-2.5 py-1 text-[12px] font-medium text-[#333333] transition-colors hover:border-[#CFCFCF] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
+                  style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out, border-color 100ms ease-out" }}
+                >
+                  <PencilIcon className="h-3 w-3" />
+                  {mode === "edit" ? "Done" : "Edit"}
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleCopy}
+                aria-label={copied ? "Copied" : "Copy email"}
+                title={copied ? "Copied" : "Copy"}
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111]"
+              >
+                <CopyIcon className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={loading}
+                aria-label="Send email"
+                title="Send"
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111] disabled:opacity-40"
+              >
+                <SendIcon className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="flex flex-col gap-3 px-4 py-3">
+            {/* Meta — To / From */}
+            <div className="flex flex-col gap-1.5">
+              <MetaRow
+                label="To"
+                mode={mode}
+                primary={fields.recipient_email}
+                secondary={fields.recipient_name}
+                onPrimaryChange={(v) => updateField("recipient_email", v)}
+                onSecondaryChange={(v) => updateField("recipient_name", v)}
+                primaryPlaceholder="recipient@example.com"
+                secondaryPlaceholder="Recipient name"
+              />
+              <MetaRow
+                label="From"
+                mode={mode}
+                primary={fields.sender_email}
+                secondary={fields.sender_name}
+                onPrimaryChange={(v) => updateField("sender_email", v)}
+                onSecondaryChange={(v) => updateField("sender_name", v)}
+                primaryPlaceholder="you@example.com"
+                secondaryPlaceholder="Your name"
+              />
+            </div>
+
+            <div className="h-px bg-[#EBEBEB]" />
+
+            {/* Subject */}
+            <div className="flex items-baseline gap-3">
+              <span className="w-[60px] shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[#999999]">
+                Subject
+              </span>
+              {mode === "edit" ? (
+                <input
+                  type="text"
+                  value={fields.subject}
+                  onChange={(e) => updateField("subject", e.target.value)}
+                  disabled={loading}
+                  className="flex-1 rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[13px] font-medium text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+                />
+              ) : (
+                <span className="flex-1 text-[13px] font-semibold text-[#111111]">
+                  {fields.subject || <em className="text-[#999999]">No subject</em>}
+                </span>
+              )}
+            </div>
+
+            <div className="h-px bg-[#EBEBEB]" />
+
+            {/* Body region */}
+            {mode === "edit" ? (
+              <textarea
+                value={fields.message_body}
+                onChange={(e) => updateField("message_body", e.target.value)}
+                rows={Math.min(20, Math.max(8, fields.message_body.split("\n").length + 2))}
+                disabled={loading}
+                className="w-full resize-y rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[13px] leading-relaxed text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+              />
+            ) : (
+              <div
+                ref={bodyRef}
+                onMouseUp={captureSelection}
+                onKeyUp={captureSelection}
+                className="select-text text-[13px] leading-relaxed text-[#111111] [&_strong]:font-semibold [&_em]:italic [&_u]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:mb-0.5"
+              >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {fields.message_body || "_(empty body)_"}
+                </ReactMarkdown>
+              </div>
+            )}
+
+            {fields.signature && (
+              <>
+                <div className="h-px bg-[#EBEBEB]" />
+                {mode === "edit" ? (
+                  <textarea
+                    value={fields.signature}
+                    onChange={(e) => updateField("signature", e.target.value)}
+                    rows={2}
+                    disabled={loading}
+                    className="w-full resize-none rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] leading-snug text-[#555555] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
+                  />
+                ) : (
+                  <div className="whitespace-pre-wrap text-[12px] leading-snug text-[#555555]">
+                    {fields.signature}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes emailCanvasIn {
+          from { opacity: 0; transform: translateY(4px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function MetaRow({
+  label,
+  mode,
+  primary,
+  secondary,
+  onPrimaryChange,
+  onSecondaryChange,
+  primaryPlaceholder,
+  secondaryPlaceholder,
+}: {
+  label: string;
+  mode: "view" | "edit";
+  primary: string;
+  secondary: string;
+  onPrimaryChange: (v: string) => void;
+  onSecondaryChange: (v: string) => void;
+  primaryPlaceholder: string;
+  secondaryPlaceholder: string;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-[60px] shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[#999999]">
+        {label}
+      </span>
+      {mode === "edit" ? (
+        <div className="flex flex-1 items-center gap-1.5">
+          <input
+            type="text"
+            value={secondary}
+            onChange={(e) => onSecondaryChange(e.target.value)}
+            placeholder={secondaryPlaceholder}
+            className="w-[160px] rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF]"
+          />
+          <input
+            type="text"
+            value={primary}
+            onChange={(e) => onPrimaryChange(e.target.value)}
+            placeholder={primaryPlaceholder}
+            className="flex-1 rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF]"
+          />
+        </div>
+      ) : (
+        <span className="flex-1 text-[12px] text-[#333333]">
+          {secondary ? (
+            <>
+              <span className="font-medium text-[#111111]">{secondary}</span>
+              {primary && <span className="text-[#999999]"> &lt;{primary}&gt;</span>}
+            </>
+          ) : (
+            <span className="text-[#777777]">{primary || "—"}</span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PencilIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function SendIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="m22 2-7 20-4-9-9-4 20-7Z" />
+      <path d="M22 2 11 13" />
+    </svg>
+  );
+}
+
+function ArrowUpIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
+    </svg>
+  );
+}

--- a/fe+convex/components/agent/EmailDraftCanvas.tsx
+++ b/fe+convex/components/agent/EmailDraftCanvas.tsx
@@ -87,7 +87,7 @@ export function EmailDraftCanvas({
       lock: lockRef,
       setLoading,
       onResolved,
-      overrideArgs: fields,
+      overrideArgs: fields as unknown as Record<string, unknown>,
     });
   }
 

--- a/fe+convex/components/agent/EmailDraftCanvas.tsx
+++ b/fe+convex/components/agent/EmailDraftCanvas.tsx
@@ -97,6 +97,18 @@ export function EmailDraftCanvas({
     setSelectionText(text);
   }
 
+  async function handleCancel() {
+    if (loading) return;
+    await runDecision({
+      approvalId: approval.id,
+      decision: "rejected",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+    });
+  }
+
   async function handleSend() {
     if (loading) return;
     await runDecision({
@@ -216,6 +228,16 @@ export function EmailDraftCanvas({
               )}
             </div>
             <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={loading}
+                aria-label="Cancel email"
+                title="Cancel"
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111] disabled:opacity-40"
+              >
+                <XIcon className="h-4 w-4" />
+              </button>
               <button
                 type="button"
                 onClick={handleCopy}
@@ -404,6 +426,15 @@ function PencilIcon({ className }: { className?: string }) {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
     </svg>
   );
 }

--- a/fe+convex/components/agent/EmailDraftCanvas.tsx
+++ b/fe+convex/components/agent/EmailDraftCanvas.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { AgentApproval } from "./types";
 import { extractInnerPayload } from "./approvalPayload";
 import { submitApproval } from "./adapters/runtime";
@@ -49,20 +47,16 @@ export function EmailDraftCanvas({
   onRejectedWithMessage,
 }: EmailDraftCanvasProps) {
   const [fields, setFields] = useState<EmailFields>(() => readEmailFields(approval));
-  const [mode, setMode] = useState<"view" | "edit">("view");
   const [selectionText, setSelectionText] = useState<string | null>(null);
   const [askInput, setAskInput] = useState("");
   const [loading, setLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const lockRef = useRef(false);
-  const bodyRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
   const askInputRef = useRef<HTMLInputElement>(null);
 
-  // Re-seed when a new approval lands (e.g. after a partial-revision round-trip).
   useEffect(() => {
     setFields(readEmailFields(approval));
-    setMode("view");
     setSelectionText(null);
     setAskInput("");
   }, [approval.id, approval.proposedPayload]);
@@ -74,42 +68,17 @@ export function EmailDraftCanvas({
   const olderPending = Math.max(0, pendingCount - 1);
 
   function captureSelection() {
-    if (mode !== "view") return;
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed || !bodyRef.current) {
-      setSelectionText(null);
-      return;
-    }
-    const anchor = sel.anchorNode;
-    const focus = sel.focusNode;
-    const within =
-      (anchor && bodyRef.current.contains(anchor)) ||
-      (focus && bodyRef.current.contains(focus));
-    if (!within) {
-      setSelectionText(null);
-      return;
-    }
-    const text = sel.toString().trim();
-    if (!text) {
-      setSelectionText(null);
-      return;
-    }
-    setSelectionText(text);
+    const ta = bodyRef.current;
+    if (!ta) return;
+    const selected = ta.value.slice(ta.selectionStart, ta.selectionEnd).trim();
+    setSelectionText(selected || null);
   }
 
-  async function handleCancel() {
-    if (loading) return;
-    await runDecision({
-      approvalId: approval.id,
-      decision: "rejected",
-      submit: submitApproval,
-      lock: lockRef,
-      setLoading,
-      onResolved,
-    });
+  function updateField<K extends keyof EmailFields>(key: K, value: string) {
+    setFields((prev) => ({ ...prev, [key]: value }));
   }
 
-  async function handleSend() {
+  async function handleConfirm() {
     if (loading) return;
     await runDecision({
       approvalId: approval.id,
@@ -122,15 +91,16 @@ export function EmailDraftCanvas({
     });
   }
 
-  async function handleCopy() {
-    const text = `Subject: ${fields.subject}\n\n${fields.message_body}${fields.signature ? `\n\n${fields.signature}` : ""}`;
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    } catch {
-      // best-effort; ignore
-    }
+  async function handleDiscard() {
+    if (loading) return;
+    await runDecision({
+      approvalId: approval.id,
+      decision: "rejected",
+      submit: submitApproval,
+      lock: lockRef,
+      setLoading,
+      onResolved,
+    });
   }
 
   async function handleAskForChanges() {
@@ -160,9 +130,11 @@ export function EmailDraftCanvas({
     }
   }
 
-  function updateField<K extends keyof EmailFields>(key: K, value: string) {
-    setFields((prev) => ({ ...prev, [key]: value }));
-  }
+  const recipientLabel = fields.recipient_name
+    ? `${fields.recipient_name} <${fields.recipient_email}>`
+    : fields.recipient_email || "—";
+
+  const bodyRows = Math.min(18, Math.max(6, fields.message_body.split("\n").length + 1));
 
   return (
     <div
@@ -172,186 +144,121 @@ export function EmailDraftCanvas({
       aria-label="Email draft"
     >
       <div className="flex flex-col gap-2 px-4 pt-3 pb-3">
-        {olderPending > 0 && (
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-[12px] font-semibold text-[#111111]">
+            Draft Email
+            {olderPending > 0 && (
+              <span className="ml-2 font-normal text-[#999999]">+{olderPending} more pending</span>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={loading}
+            aria-label="Discard draft"
+            title="Discard"
+            className="flex h-6 w-6 items-center justify-center rounded-[5px] text-[#AAAAAA] transition-colors hover:bg-[#F4F4F4] hover:text-[#111111] disabled:opacity-40"
+          >
+            <XIcon className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        {/* Email card */}
+        <div className="flex flex-col overflow-hidden rounded-[8px] border border-[#EBEBEB] bg-[#FAFAFA]">
+          {/* To — read-only display */}
+          <div className="flex items-center gap-2 border-b border-[#F1F1F1] px-3 py-1.5">
+            <span className="w-[46px] shrink-0 text-[10.5px] font-semibold uppercase tracking-wide text-[#AAAAAA]">To</span>
+            <span className="truncate text-[12px] text-[#444444]">{recipientLabel}</span>
+          </div>
+
+          {/* Subject — editable input */}
+          <div className="flex items-center gap-2 border-b border-[#F1F1F1] px-3 py-1.5">
+            <span className="w-[46px] shrink-0 text-[10.5px] font-semibold uppercase tracking-wide text-[#AAAAAA]">Subj</span>
+            <input
+              type="text"
+              value={fields.subject}
+              onChange={(e) => updateField("subject", e.target.value)}
+              disabled={loading}
+              placeholder="Subject"
+              className="flex-1 bg-transparent text-[12.5px] font-medium text-[#111111] outline-none placeholder-[#CCCCCC] disabled:opacity-50"
+            />
+          </div>
+
+          {/* Body — always-editable textarea with selection capture */}
+          <textarea
+            ref={bodyRef}
+            value={fields.message_body}
+            onChange={(e) => updateField("message_body", e.target.value)}
+            onMouseUp={captureSelection}
+            onKeyUp={captureSelection}
+            rows={bodyRows}
+            disabled={loading}
+            placeholder="Message body…"
+            className="w-full resize-y bg-transparent px-3 py-2.5 font-mono text-[12.5px] leading-relaxed text-[#111111] outline-none placeholder-[#CCCCCC] disabled:opacity-50"
+          />
+
+          {/* Signature */}
+          {fields.signature && (
+            <>
+              <div className="h-px bg-[#F1F1F1]" />
+              <textarea
+                value={fields.signature}
+                onChange={(e) => updateField("signature", e.target.value)}
+                rows={2}
+                disabled={loading}
+                className="w-full resize-none bg-transparent px-3 py-2 text-[12px] leading-snug text-[#888888] outline-none disabled:opacity-50"
+              />
+            </>
+          )}
+        </div>
+
+        {/* Action bar */}
+        {selectionText ? (
+          <div className="flex items-center gap-1.5 rounded-[8px] border border-[#E0E0E0] bg-[#FFFFFF] px-2.5 py-1.5">
+            <PencilIcon className="h-3 w-3 shrink-0 text-[#777777]" />
+            <input
+              ref={askInputRef}
+              type="text"
+              value={askInput}
+              onChange={(e) => setAskInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && askInput.trim()) {
+                  e.preventDefault();
+                  handleAskForChanges();
+                }
+                if (e.key === "Escape") {
+                  setSelectionText(null);
+                  setAskInput("");
+                }
+              }}
+              placeholder="Ask for changes to selection…"
+              disabled={loading}
+              className="flex-1 bg-transparent text-[12px] text-[#111111] placeholder-[#BBBBBB] outline-none disabled:opacity-40"
+            />
+            <button
+              type="button"
+              onClick={handleAskForChanges}
+              disabled={loading || !askInput.trim()}
+              aria-label="Request changes"
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A] text-white transition-opacity hover:opacity-90 disabled:opacity-30"
+            >
+              <ArrowUpIcon className="h-3 w-3" />
+            </button>
+          </div>
+        ) : (
           <div className="flex justify-end">
-            <span className="text-[11px] text-[#999999]">+{olderPending} more pending</span>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={loading}
+              className="flex h-7 items-center rounded-[6px] bg-[#0A0A0A] px-4 text-[12px] font-medium text-white transition-colors hover:bg-[#222222] active:scale-[0.97] disabled:opacity-40"
+              style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out" }}
+            >
+              {loading ? "Sending…" : "Confirm"}
+            </button>
           </div>
         )}
-
-        <div className="rounded-[10px] border border-[#EBEBEB] bg-[#FAFAFA]">
-          {/* Top bar */}
-          <div className="flex items-center justify-between gap-2 border-b border-[#EBEBEB] px-3 py-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              {selectionText && mode === "view" ? (
-                <div className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[999px] border border-[#E0E0E0] bg-[#FFFFFF] px-2.5 py-1">
-                  <PencilIcon className="h-3 w-3 shrink-0 text-[#777777]" />
-                  <input
-                    ref={askInputRef}
-                    type="text"
-                    value={askInput}
-                    onChange={(e) => setAskInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && askInput.trim()) {
-                        e.preventDefault();
-                        handleAskForChanges();
-                      }
-                      if (e.key === "Escape") {
-                        setSelectionText(null);
-                        setAskInput("");
-                      }
-                    }}
-                    placeholder="Ask for changes"
-                    disabled={loading}
-                    className="w-full bg-transparent text-[12px] text-[#111111] placeholder-[#BBBBBB] outline-none disabled:opacity-40"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleAskForChanges}
-                    disabled={loading || !askInput.trim()}
-                    aria-label="Send changes"
-                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#0A0A0A] text-white transition-opacity hover:opacity-90 disabled:opacity-30"
-                  >
-                    <ArrowUpIcon className="h-3 w-3" />
-                  </button>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setMode((m) => (m === "edit" ? "view" : "edit"))}
-                  disabled={loading}
-                  className="inline-flex items-center gap-1.5 rounded-[999px] border border-[#E0E0E0] bg-[#FFFFFF] px-2.5 py-1 text-[12px] font-medium text-[#333333] transition-colors hover:border-[#CFCFCF] hover:bg-[#F4F4F4] active:scale-[0.97] disabled:opacity-40"
-                  style={{ transition: "transform 120ms ease-out, background-color 100ms ease-out, border-color 100ms ease-out" }}
-                >
-                  <PencilIcon className="h-3 w-3" />
-                  {mode === "edit" ? "Done" : "Edit"}
-                </button>
-              )}
-            </div>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={handleCancel}
-                disabled={loading}
-                aria-label="Cancel email"
-                title="Cancel"
-                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111] disabled:opacity-40"
-              >
-                <XIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={handleCopy}
-                aria-label={copied ? "Copied" : "Copy email"}
-                title={copied ? "Copied" : "Copy"}
-                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111]"
-              >
-                <CopyIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={handleSend}
-                disabled={loading}
-                aria-label="Send email"
-                title="Send"
-                className="flex h-7 w-7 items-center justify-center rounded-[6px] text-[#555555] transition-colors hover:bg-[#F1F1F1] hover:text-[#111111] disabled:opacity-40"
-              >
-                <SendIcon className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
-
-          {/* Body */}
-          <div className="flex flex-col gap-3 px-4 py-3">
-            {/* Meta — To / From */}
-            <div className="flex flex-col gap-1.5">
-              <MetaRow
-                label="To"
-                mode={mode}
-                primary={fields.recipient_email}
-                secondary={fields.recipient_name}
-                onPrimaryChange={(v) => updateField("recipient_email", v)}
-                onSecondaryChange={(v) => updateField("recipient_name", v)}
-                primaryPlaceholder="recipient@example.com"
-                secondaryPlaceholder="Recipient name"
-              />
-              <MetaRow
-                label="From"
-                mode={mode}
-                primary={fields.sender_email}
-                secondary={fields.sender_name}
-                onPrimaryChange={(v) => updateField("sender_email", v)}
-                onSecondaryChange={(v) => updateField("sender_name", v)}
-                primaryPlaceholder="you@example.com"
-                secondaryPlaceholder="Your name"
-              />
-            </div>
-
-            <div className="h-px bg-[#EBEBEB]" />
-
-            {/* Subject */}
-            <div className="flex items-baseline gap-3">
-              <span className="w-[60px] shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[#999999]">
-                Subject
-              </span>
-              {mode === "edit" ? (
-                <input
-                  type="text"
-                  value={fields.subject}
-                  onChange={(e) => updateField("subject", e.target.value)}
-                  disabled={loading}
-                  className="flex-1 rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[13px] font-medium text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
-                />
-              ) : (
-                <span className="flex-1 text-[13px] font-semibold text-[#111111]">
-                  {fields.subject || <em className="text-[#999999]">No subject</em>}
-                </span>
-              )}
-            </div>
-
-            <div className="h-px bg-[#EBEBEB]" />
-
-            {/* Body region */}
-            {mode === "edit" ? (
-              <textarea
-                value={fields.message_body}
-                onChange={(e) => updateField("message_body", e.target.value)}
-                rows={Math.min(20, Math.max(8, fields.message_body.split("\n").length + 2))}
-                disabled={loading}
-                className="w-full resize-y rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[13px] leading-relaxed text-[#111111] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
-              />
-            ) : (
-              <div
-                ref={bodyRef}
-                onMouseUp={captureSelection}
-                onKeyUp={captureSelection}
-                className="select-text text-[13px] leading-relaxed text-[#111111] [&_strong]:font-semibold [&_em]:italic [&_u]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:mb-0.5"
-              >
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {fields.message_body || "_(empty body)_"}
-                </ReactMarkdown>
-              </div>
-            )}
-
-            {fields.signature && (
-              <>
-                <div className="h-px bg-[#EBEBEB]" />
-                {mode === "edit" ? (
-                  <textarea
-                    value={fields.signature}
-                    onChange={(e) => updateField("signature", e.target.value)}
-                    rows={2}
-                    disabled={loading}
-                    className="w-full resize-none rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1.5 text-[12px] leading-snug text-[#555555] outline-none focus:border-[#CFCFCF] disabled:opacity-40"
-                  />
-                ) : (
-                  <div className="whitespace-pre-wrap text-[12px] leading-snug text-[#555555]">
-                    {fields.signature}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
       </div>
 
       <style>{`
@@ -360,63 +267,6 @@ export function EmailDraftCanvas({
           to   { opacity: 1; transform: translateY(0); }
         }
       `}</style>
-    </div>
-  );
-}
-
-function MetaRow({
-  label,
-  mode,
-  primary,
-  secondary,
-  onPrimaryChange,
-  onSecondaryChange,
-  primaryPlaceholder,
-  secondaryPlaceholder,
-}: {
-  label: string;
-  mode: "view" | "edit";
-  primary: string;
-  secondary: string;
-  onPrimaryChange: (v: string) => void;
-  onSecondaryChange: (v: string) => void;
-  primaryPlaceholder: string;
-  secondaryPlaceholder: string;
-}) {
-  return (
-    <div className="flex items-baseline gap-3">
-      <span className="w-[60px] shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[#999999]">
-        {label}
-      </span>
-      {mode === "edit" ? (
-        <div className="flex flex-1 items-center gap-1.5">
-          <input
-            type="text"
-            value={secondary}
-            onChange={(e) => onSecondaryChange(e.target.value)}
-            placeholder={secondaryPlaceholder}
-            className="w-[160px] rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF]"
-          />
-          <input
-            type="text"
-            value={primary}
-            onChange={(e) => onPrimaryChange(e.target.value)}
-            placeholder={primaryPlaceholder}
-            className="flex-1 rounded-[4px] border border-[#E0E0E0] bg-[#FFFFFF] px-2 py-1 text-[12px] text-[#111111] outline-none focus:border-[#CFCFCF]"
-          />
-        </div>
-      ) : (
-        <span className="flex-1 text-[12px] text-[#333333]">
-          {secondary ? (
-            <>
-              <span className="font-medium text-[#111111]">{secondary}</span>
-              {primary && <span className="text-[#999999]"> &lt;{primary}&gt;</span>}
-            </>
-          ) : (
-            <span className="text-[#777777]">{primary || "—"}</span>
-          )}
-        </span>
-      )}
     </div>
   );
 }
@@ -435,24 +285,6 @@ function XIcon({ className }: { className?: string }) {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
       <path d="M18 6 6 18" />
       <path d="m6 6 12 12" />
-    </svg>
-  );
-}
-
-function CopyIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <rect x="9" y="9" width="13" height="13" rx="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  );
-}
-
-function SendIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="m22 2-7 20-4-9-9-4 20-7Z" />
-      <path d="M22 2 11 13" />
     </svg>
   );
 }

--- a/fe+convex/components/agent/approvalPayload.ts
+++ b/fe+convex/components/agent/approvalPayload.ts
@@ -38,10 +38,18 @@ export const FIELD_LABELS: Record<string, string> = {
   booked_time: "Start Time",
   booked_end_time: "End Time",
   page_url: "Booking Page",
+  // Email outreach
+  recipient_name: "Recipient",
+  recipient_email: "To",
+  subject: "Subject",
+  message_body: "Message",
+  sender_name: "From",
+  sender_email: "Sender Email",
+  signature: "Signature",
 };
 
 // Keys whose values can be long enough to warrant clamping in the receipt UI.
-const LONG_TEXT_KEYS = new Set(["description", "summary", "notes"]);
+const LONG_TEXT_KEYS = new Set(["description", "summary", "notes", "message_body", "signature"]);
 
 // Keys that should be interpreted as a date (YYYY-MM-DD or full ISO string).
 const DATE_KEYS = new Set(["event_date", "date"]);

--- a/fe+convex/components/agent/composerApproval.ts
+++ b/fe+convex/components/agent/composerApproval.ts
@@ -166,7 +166,11 @@ export interface DecisionResult {
 export async function runDecision(args: {
   approvalId: string;
   decision: "approved" | "rejected";
-  submit: (approvalId: string, decision: "approved" | "rejected") => Promise<void>;
+  submit: (
+    approvalId: string,
+    decision: "approved" | "rejected",
+    overrideArgs?: Record<string, unknown>,
+  ) => Promise<void>;
   /**
    * Mutable ref holding the in-flight flag. Checked and set synchronously so
    * two click handlers fired in the same tick cannot both pass the gate.
@@ -175,12 +179,14 @@ export async function runDecision(args: {
   setLoading?: (next: boolean) => void;
   onResolved?: (decision: "approved" | "rejected") => void | Promise<void>;
   onError?: (error: unknown) => void;
+  /** Optional field overrides to merge into the tool payload before execution. */
+  overrideArgs?: Record<string, unknown>;
 }): Promise<DecisionResult> {
   if (args.lock.current) return { status: "skipped" };
   args.lock.current = true;
   args.setLoading?.(true);
   try {
-    await args.submit(args.approvalId, args.decision);
+    await args.submit(args.approvalId, args.decision, args.overrideArgs);
     await args.onResolved?.(args.decision);
     return { status: "submitted", decision: args.decision };
   } catch (error) {

--- a/fe+convex/components/agent/types.ts
+++ b/fe+convex/components/agent/types.ts
@@ -113,6 +113,7 @@ export interface AgentApproval {
   proposedPayload: Record<string, unknown>;
   status: "pending" | "approved" | "rejected";
   createdAt: number;
+  actionType?: string;
 }
 
 export interface ContextLink {


### PR DESCRIPTION
## Summary

- **EmailDraftCanvas** — new dedicated approval UI for `send_outreach_email` with view/edit modes, text-selection-based revision requests (highlight a passage → ask for a change → agent re-drafts), copy-to-clipboard, and send
- **ComposerApprovalPrompt refactor** — email approvals are now routed to `EmailDraftCanvas`; generic approvals use a cleaned-up `GenericApprovalPrompt`
- **AgentMail integration** — approval-gated `send_outreach_email` tool wired end-to-end through runtime policy, tool executor, and MCP server
- **Modal MCP app** — `agent/apps/mcp/modal_app.py` for deploying the MCP server on Modal
- **System prompt improvements** — agent instructed to fetch full event + recipient details before drafting, never using placeholder content
- **Dashboard + routing** — recharts-based dashboard at `/dashboard`, event detail moved to `/dashboard/events/data/[eventId]`

## Bug fix included

`handleSend` previously dropped field edits if the user clicked "Done" (returning to view mode) before hitting Send. Fixed by always passing current `fields` state as `overrideArgs`.

## Test plan

- [ ] Ask agent to draft an outreach email → approval card shows EmailDraftCanvas
- [ ] Edit a field in edit mode, click Done, then Send → edited values are sent
- [ ] Highlight text in body → "Ask for changes" input appears → submit → agent re-drafts
- [ ] Copy button copies subject + body + signature to clipboard
- [ ] Non-email approvals still render the generic approval prompt
- [ ] `send_outreach_email` triggers approval gate (not executed inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)