### PR TITLE
feat(agent): unblock Convex writes; hide backend names and IDs

### DIFF
--- a/agent/core/clients/convex.py
+++ b/agent/core/clients/convex.py
@@ -13,6 +13,7 @@ class ConvexClient:
     def __init__(self) -> None:
         self._url = os.environ["CONVEX_URL"].rstrip("/")
         self._key = os.environ["CONVEX_DEPLOY_KEY"]
+        self._agent_token = os.environ.get("AGENT_SERVICE_TOKEN")
         self._http: httpx.AsyncClient | None = None
 
     async def __aenter__(self) -> "ConvexClient":
@@ -60,7 +61,10 @@ class ConvexClient:
         return await self._call("query", path, args or {})
 
     async def mutation(self, path: str, args: dict | None = None) -> Any:
-        return await self._call("mutation", path, args or {})
+        merged = dict(args or {})
+        if self._agent_token and "_agent_token" not in merged:
+            merged["_agent_token"] = self._agent_token
+        return await self._call("mutation", path, merged)
 
     # ── Events ──
 

--- a/agent/core/clients/convex.py
+++ b/agent/core/clients/convex.py
@@ -61,6 +61,16 @@ class ConvexClient:
         return await self._call("query", path, args or {})
 
     async def mutation(self, path: str, args: dict | None = None) -> Any:
+        return await self._call("mutation", path, args or {})
+
+    async def _admin_mutation(self, path: str, args: dict | None = None) -> Any:
+        """Mutation against an admin-gated Convex function.
+
+        Only paths whose validator includes the optional `_agent_token` field
+        (currently the gated mutations in `convex/events.ts`) may be called
+        through this. General mutations must use `mutation()` to avoid
+        ArgumentValidationError on the extra field.
+        """
         merged = dict(args or {})
         if self._agent_token and "_agent_token" not in merged:
             merged["_agent_token"] = self._agent_token
@@ -76,10 +86,12 @@ class ConvexClient:
         return rows if isinstance(rows, list) else []
 
     async def update_event_status(self, event_id: str, status: str) -> None:
-        await self.mutation("events:updateEventStatus", {"event_id": event_id, "status": status})
+        await self._admin_mutation(
+            "events:updateEventStatus", {"event_id": event_id, "status": status}
+        )
 
     async def create_event(self, event: dict) -> str:
-        return await self.mutation("events:createEvent", event)
+        return await self._admin_mutation("events:createEvent", event)
 
     async def apply_inbound_milestones(
         self,
@@ -88,7 +100,7 @@ class ConvexClient:
         speaker_confirmed: bool | None = None,
         room_confirmed: bool | None = None,
     ) -> None:
-        await self.mutation(
+        await self._admin_mutation(
             "events:applyInboundMilestones",
             {
                 "event_id": event_id,
@@ -113,7 +125,7 @@ class ConvexClient:
         speaker_confirmed: bool | None = None,
         room_confirmed: bool | None = None,
     ) -> dict | None:
-        return await self.mutation(
+        return await self._admin_mutation(
             "events:updateEvent",
             {
                 "event_id": event_id,
@@ -219,7 +231,7 @@ class ConvexClient:
         await self.mutation("outreach:releaseInboundReceipt", {"message_id": message_id})
 
     async def delete_event(self, event_id: str) -> None:
-        await self.mutation("events:deleteEvent", {"event_id": event_id})
+        await self._admin_mutation("events:deleteEvent", {"event_id": event_id})
 
     async def delete_outreach_for_event(self, event_id: str) -> None:
         await self.mutation("outreach:deleteOutreachForEvent", {"event_id": event_id})

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -20,7 +20,7 @@ def _build_system_prompt() -> str:
         "from today's date (use the next upcoming occurrence if the date has already passed this year). "
         "Always pass ISO 8601 dates (YYYY-MM-DD) to tools. "
         "You are the Event Organizer runtime assistant. "
-        "You have live access to Convex event and attendance data and Attio people/speaker data via in-process tools. "
+        "You have live access to event, attendance, contact, and speaker data via in-process tools. "
         "Use the available tools whenever the user asks for current or specific business data. "
         "For latest or recent event attendance questions, first call `list_events`, then call "
         "`get_event_attendance` for the newest relevant event. "
@@ -34,7 +34,7 @@ def _build_system_prompt() -> str:
         "`status` and `source` must use the canonical live Attio option titles "
         "(source: outreach, warm, in bound, event, alumni; status: Prospect, Engaged, Confirmed, Declined). "
         "Prefer deriving IDs through tool lookups instead of asking the user for them when possible. "
-        "If a tool fails, mention the tool name and the concrete failure. "
+        "If a tool fails, describe the user-visible effect in plain language. "
         "Do not invent permission issues, authentication issues, environment restrictions, "
         "or unrelated APIs unless a tool actually failed with that error. "
         "Only edit or write external state when the application explicitly approves it. "
@@ -45,7 +45,17 @@ def _build_system_prompt() -> str:
         "If no location is specified, default to '16 Washington Place'. "
         "Do not use internal field names (event_date, needs_outreach, event_time, etc.) when talking "
         "to the user — use natural language equivalents instead. "
-        "When updating an event, confirm which fields will change before calling update_event_safe."
+        "When updating an event, confirm which fields will change before calling update_event_safe. "
+        "Never name internal systems or storage when talking to the user. Do not say 'Convex', 'the "
+        "database', 'the backend', or quote internal helper names like 'requireAdminMember' — speak "
+        "about events, attendance, contacts, and bookings directly. When a tool fails, describe the "
+        "user-visible effect (e.g. 'I couldn't save the event due to a permissions issue') without "
+        "naming the storage system or quoting internal error helpers. "
+        "Never echo internal identifiers back to the user. Do not include event_id, record_id, "
+        "thread_id, attio_record_id, OnceHub booking references, or any other opaque token in your "
+        "reply text. Confirm created or updated entities by title, date, time, and other "
+        "human-readable details. Internal IDs may be passed between tools but must not appear in "
+        "what the user reads."
     )
 
 
@@ -208,7 +218,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "list_events",
-        "description": "List Convex events, typically to find the newest relevant event before a follow-up read.",
+        "description": "List events, typically to find the newest relevant event before a follow-up read.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -219,7 +229,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "get_event",
-        "description": "Fetch one Convex event when you already know the event ID.",
+        "description": "Fetch one event when you already know the event ID.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -240,7 +250,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "get_event_outreach",
-        "description": "Return per-event outreach rows and responses for a specific Convex event.",
+        "description": "Return per-event outreach rows and responses for a specific event.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -291,7 +301,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "update_event_safe",
-        "description": "Safely patch approved event fields and milestone booleans for a Convex event.",
+        "description": "Safely patch approved event fields and milestone booleans.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -336,9 +346,9 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
         "description": (
             "Book the Leslie eLab Lean/Launchpad room for a specific slot. "
             "Approval-gated. On approval, submits to OnceHub under the shared club "
-            "booking profile and persists the receipt to Convex event_room_bookings. "
+            "booking profile and persists the booking record. "
             "If event_id is provided, the event's room_confirmed flag is stickied true; "
-            "if event_id is omitted, a new Convex event is created from the booking."
+            "if event_id is omitted, a new event record is created from the booking."
         ),
         "input_schema": {
             "type": "object",
@@ -347,7 +357,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
                 "duration_minutes":    {"type": "integer"},
                 "title":               {"type": "string", "description": "Event/booking title"},
                 "num_attendees":       {"type": "integer"},
-                "event_id":            {"type": "string", "description": "Optional: existing Convex event id"},
+                "event_id":            {"type": "string", "description": "Optional: existing event id"},
                 "description":         {"type": "string"},
                 "event_type":          {"type": "string"},
                 "target_profile":      {"type": "string"},
@@ -357,7 +367,7 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "get_event_room_booking",
-        "description": "Return the latest OnceHub booking record for a Convex event, or null.",
+        "description": "Return the latest OnceHub booking record for an event, or null.",
         "input_schema": {
             "type": "object",
             "properties": {

--- a/fe+convex/convex/eboard.ts
+++ b/fe+convex/convex/eboard.ts
@@ -20,6 +20,26 @@ export async function requireAdminMember(ctx: MutationCtx | QueryCtx) {
   return { authUser, member };
 }
 
+/**
+ * Admin gate that also accepts a service token for agent-side calls.
+ * The agent runtime authenticates with a Convex deploy key, which does not
+ * resolve to a Better Auth user, so user-bound `requireAdminMember` cannot
+ * succeed for it. When a caller passes `_agent_token` matching
+ * `AGENT_SERVICE_TOKEN`, treat the call as a trusted agent invocation and
+ * skip the user lookup.
+ */
+export async function requireAdminOrAgent(
+  ctx: MutationCtx | QueryCtx,
+  agentToken: string | undefined
+) {
+  const expected = process.env.AGENT_SERVICE_TOKEN;
+  if (expected && agentToken && agentToken === expected) {
+    return { authUser: null, member: null, isAgent: true } as const;
+  }
+  const result = await requireAdminMember(ctx);
+  return { ...result, isAgent: false } as const;
+}
+
 export const getCurrentMember = query({
   args: {},
   handler: async (ctx) => {

--- a/fe+convex/convex/events.test.ts
+++ b/fe+convex/convex/events.test.ts
@@ -13,6 +13,14 @@ let requireAdminMemberImpl = async () => ({ authUser: { _id: "user:1" }, member:
 
 mock.module("./eboard", () => ({
   requireAdminMember: (...args: unknown[]) => requireAdminMemberImpl(...args),
+  requireAdminOrAgent: async (ctx: unknown, agentToken: string | undefined) => {
+    const expected = process.env.AGENT_SERVICE_TOKEN;
+    if (expected && agentToken && agentToken === expected) {
+      return { authUser: null, member: null, isAgent: true } as const;
+    }
+    const result = await requireAdminMemberImpl();
+    return { ...result, isAgent: false } as const;
+  },
 }));
 
 class FakeIndexRangeBuilder {

--- a/fe+convex/convex/events.ts
+++ b/fe+convex/convex/events.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { requireAdminMember } from "./eboard";
+import { requireAdminOrAgent } from "./eboard";
 
 export const getEvent = query({
   args: { event_id: v.id("events") },
@@ -22,12 +22,14 @@ export const createEvent = mutation({
     needs_outreach: v.boolean(),
     status: v.string(),
     created_by: v.optional(v.string()),
+    _agent_token: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await requireAdminMember(ctx);
+    const { _agent_token, ...eventArgs } = args;
+    await requireAdminOrAgent(ctx, _agent_token);
 
     return await ctx.db.insert("events", {
-      ...args,
+      ...eventArgs,
       speaker_confirmed: false,
       room_confirmed: false,
       created_at: Date.now(),
@@ -36,9 +38,13 @@ export const createEvent = mutation({
 });
 
 export const updateEventStatus = mutation({
-  args: { event_id: v.id("events"), status: v.string() },
-  handler: async (ctx, { event_id, status }) => {
-    await requireAdminMember(ctx);
+  args: {
+    event_id: v.id("events"),
+    status: v.string(),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { event_id, status, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
 
     await ctx.db.patch(event_id, { status });
   },
@@ -59,6 +65,7 @@ export const updateEvent = mutation({
     needs_outreach: v.optional(v.boolean()),
     speaker_confirmed: v.optional(v.boolean()),
     room_confirmed: v.optional(v.boolean()),
+    _agent_token: v.optional(v.string()),
   },
   handler: async (
     ctx,
@@ -76,9 +83,10 @@ export const updateEvent = mutation({
       needs_outreach,
       speaker_confirmed,
       room_confirmed,
+      _agent_token,
     }
   ) => {
-    await requireAdminMember(ctx);
+    await requireAdminOrAgent(ctx, _agent_token);
 
     const event = await ctx.db.get(event_id);
     if (!event) {
@@ -126,9 +134,12 @@ export const listEvents = query({
 });
 
 export const deleteEvent = mutation({
-  args: { event_id: v.id("events") },
-  handler: async (ctx, { event_id }) => {
-    await requireAdminMember(ctx);
+  args: {
+    event_id: v.id("events"),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { event_id, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
 
     const event = await ctx.db.get(event_id);
     if (!event) {
@@ -169,9 +180,13 @@ export const applyInboundMilestones = mutation({
     event_id: v.id("events"),
     speaker_confirmed: v.optional(v.boolean()),
     room_confirmed: v.optional(v.boolean()),
+    _agent_token: v.optional(v.string()),
   },
-  handler: async (ctx, { event_id, speaker_confirmed, room_confirmed }) => {
-    await requireAdminMember(ctx);
+  handler: async (
+    ctx,
+    { event_id, speaker_confirmed, room_confirmed, _agent_token }
+  ) => {
+    await requireAdminOrAgent(ctx, _agent_token);
 
     const event = await ctx.db.get(event_id);
     if (!event) throw new Error(`Event not found: ${event_id}`);


### PR DESCRIPTION
## Summary
Two related agent fixes bundled here.

**1. Admin gate accepts a service token for agent-side calls.** The agent runtime authenticates to Convex with a deploy key, which doesn't resolve to a Better Auth user — so `requireAdminMember` was throwing on every agent-initiated event mutation (`createEvent`, `updateEvent`, `applyInboundMilestones`, `deleteEvent`). New helper `requireAdminOrAgent(ctx, agentToken)` in `eboard.ts` bypasses the user lookup when the supplied token matches `process.env.AGENT_SERVICE_TOKEN`; otherwise it delegates to `requireAdminMember`. The five gated mutations in `events.ts` now accept an optional `_agent_token` arg. `ConvexClient` injects the token only on those gated paths via a private `_admin_mutation` helper — general mutations (thread/message/run sync, outreach, contact assignments, room bookings) keep the plain `mutation()` so their strict validators don't reject the extra field.

**2. Stop the assistant leaking backend details to users.** Real conversation traces showed the model saying things like "create the event in Convex", "the Convex backend returned…", and quoting internal helpers (`requireAdminMember`), plus echoing opaque identifiers (`Event ID: jh72dfw…`). The system prompt and tool descriptions in `anthropic_adapter.py` were *teaching* the model the backend's name. Rewrote the prompt to drop "Convex"/"Attio" naming, added two explicit rules (no internal-system names, no echoed IDs), and stripped "Convex" from the affected tool descriptions. OnceHub mentions remain because OnceHub is a user-facing third-party service.

UI auth path is unchanged. With `AGENT_SERVICE_TOKEN` unset on either side, behavior matches today exactly — safe to deploy code first, secret second.

## Deploy ordering
1. Merge + deploy Convex functions (`npx convex deploy`) — no behavior change yet.
2. `cd fe+convex && npx convex env set AGENT_SERVICE_TOKEN <secret>` (and any prod deployment).
3. Set `AGENT_SERVICE_TOKEN` to the same value on the agent runtime (Modal secret in `doppler-v1`).
4. Redeploy the agent.

## Test plan
- [x] `cd fe+convex && bun test convex/events.test.ts` → 10 pass (mock module updated to mirror `requireAdminOrAgent`).
- [ ] After deploy: agent `create_event` lands in Convex without "Admin access required".
- [ ] After deploy: non-admin user from the UI still hits `requireAdminMember` and is rejected.
- [ ] After deploy: OnceHub booking → `room_confirmed` flip works end-to-end.
- [ ] Replay the failing trace ("Book me an event on May 29 4:15–5:45…") — confirmation should not say "Convex" or quote the new event id.
- [ ] Negative check: ask the agent "what database do you use?" — answer should not name the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)