### PR TITLE
Fix OnceHub booking when Convex preflight fails

### DIFF
--- a/agent/apps/mcp/service.py
+++ b/agent/apps/mcp/service.py
@@ -536,12 +536,21 @@ async def book_oncehub_room(
     omitted a new event is created from the booking details and the
     resulting event id is returned.
     """
-    # Validate the event exists before the irreversible OnceHub booking so a
-    # stale event_id fails fast rather than leaving a booking with no receipt.
+    # Validate the event exists before the irreversible OnceHub booking when
+    # Convex is reachable. If Convex itself is misconfigured or temporarily
+    # unavailable, do not block the OnceHub submission: the room hold is the
+    # user-visible action, and the post-booking sync block below already
+    # reports Convex failures without hiding the booking reference.
+    preflight_convex_error: str | None = None
     if event_id:
-        async with ConvexClient() as convex:
-            if not await convex.get_event(event_id):
-                raise ValueError(f"Event not found: {event_id}")
+        try:
+            async with ConvexClient() as convex:
+                if not await convex.get_event(event_id):
+                    raise ValueError(f"Event not found: {event_id}")
+        except ValueError:
+            raise
+        except Exception as exc:
+            preflight_convex_error = str(exc)
 
     async with OnceHubClient() as oncehub:
         room = await oncehub.resolve_room()
@@ -564,7 +573,7 @@ async def book_oncehub_room(
 
     event_created = False
     convex_sync = "ok"
-    convex_error: str | None = None
+    convex_error: str | None = preflight_convex_error
     effective_event_id = event_id
 
     # OnceHub booking has succeeded by this point. Any Convex write failure
@@ -617,7 +626,13 @@ async def book_oncehub_room(
             )
     except Exception as exc:
         convex_sync = "failed"
-        convex_error = str(exc)
+        if preflight_convex_error:
+            convex_error = (
+                "Preflight event validation failed: "
+                f"{preflight_convex_error}; post-booking sync failed: {exc}"
+            )
+        else:
+            convex_error = str(exc)
 
     return {
         "event_id": effective_event_id,
@@ -626,6 +641,7 @@ async def book_oncehub_room(
         "booking_status": receipt.status,
         "convex_sync": convex_sync,
         "convex_error": convex_error,
+        "preflight_convex_error": preflight_convex_error,
         "room_label": room.label,
         "page_url": room.page_url,
         "booked_date": booked_date,

--- a/agent/config.yaml
+++ b/agent/config.yaml
@@ -17,7 +17,7 @@ oncehub:
 
     # OnceHub internal option IDs.
     affiliation_id: "457707" # Undergrad
-    school_id: "453232" # Tandon
+    school_id: "453232" # CAS
     pronouns_id: "" # Blank skips pronouns.
 
   option_reference:

--- a/agent/tests/test_oncehub_mcp_service.py
+++ b/agent/tests/test_oncehub_mcp_service.py
@@ -246,6 +246,59 @@ async def test_book_oncehub_room_uses_existing_event_when_provided(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_book_oncehub_room_fails_fast_when_existing_event_is_confirmed_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fakes(monkeypatch)
+    state["get_event_result"] = None
+    tz = ZoneInfo("America/New_York")
+    epoch = int(datetime(2026, 5, 16, 10, 0, tzinfo=tz).timestamp() * 1000)
+
+    with pytest.raises(ValueError, match="Event not found: evt_missing"):
+        await mcp_service.book_oncehub_room(
+            slot_start_epoch_ms=epoch,
+            duration_minutes=60,
+            title="Workshop",
+            num_attendees=20,
+            event_id="evt_missing",
+        )
+
+    assert state["booking_calls"] == []
+    assert state["upsert_booking_calls"] == []
+
+
+@pytest.mark.asyncio
+async def test_book_oncehub_room_does_not_block_on_convex_preflight_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fakes(monkeypatch)
+
+    class FlakyPreflightConvex(FakeConvexClient):
+        async def get_event(self, event_id: str) -> dict | None:
+            raise RuntimeError("Convex preflight unavailable")
+
+    monkeypatch.setattr(mcp_service, "ConvexClient", lambda: FlakyPreflightConvex(state))
+
+    tz = ZoneInfo("America/New_York")
+    epoch = int(datetime(2026, 5, 16, 10, 0, tzinfo=tz).timestamp() * 1000)
+
+    result = await mcp_service.book_oncehub_room(
+        slot_start_epoch_ms=epoch,
+        duration_minutes=60,
+        title="Workshop",
+        num_attendees=20,
+        event_id="evt_existing",
+    )
+
+    assert len(state["booking_calls"]) == 1
+    assert result["booking_reference"] == "bk_1"
+    assert result["event_id"] == "evt_existing"
+    assert result["convex_sync"] == "ok"
+    assert result["preflight_convex_error"] == "Convex preflight unavailable"
+    assert "Convex preflight unavailable" in (result["convex_error"] or "")
+
+
+@pytest.mark.asyncio
 async def test_book_oncehub_room_preserves_receipt_when_convex_upsert_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

This PR fixes the agent booking path so a Convex preflight/configuration failure no longer prevents the irreversible OnceHub room booking from being submitted. The tool still fails fast when Convex is reachable and confirms that a supplied `event_id` does not exist. After OnceHub succeeds, Convex persistence remains best-effort and returns recoverable partial-failure details instead of hiding the booking reference.

It also corrects the stale `school_id` comment in `agent/config.yaml` from Tandon to CAS.

## Changes

- Wrap existing-event Convex validation in a preflight try/catch.
- Preserve `ValueError` for confirmed missing events.
- Return `preflight_convex_error` so the agent/operator can see when validation was skipped because Convex was unavailable.
- Add regression tests for confirmed missing events and Convex preflight outage behavior.
- Correct the OnceHub config comment for `school_id: "453232"`.

## Tests

```bash
cd agent && python3.11 -m pytest tests/test_oncehub_mcp_service.py -q
# 8 passed

cd agent && python3.11 -m py_compile apps/mcp/service.py tests/test_oncehub_mcp_service.py
```

## Review

@claude please review the Convex preflight/OnceHub booking failure-mode behavior.
