### PR TITLE
feat(agent): inline editable email draft cards (no more approval pause)

### DIFF
--- a/agent/core/clients/convex.py
+++ b/agent/core/clients/convex.py
@@ -272,6 +272,38 @@ class ConvexClient:
             {"event_id": event_id},
         )
 
+    # ── Email drafts ──
+
+    async def create_email_draft(
+        self,
+        *,
+        external_id: str,
+        thread_id: str,
+        run_id: str | None,
+        to_name: str,
+        to_email: str,
+        subject: str,
+        body: str,
+        from_name: str | None = None,
+        from_email: str | None = None,
+        signature: str | None = None,
+    ) -> str:
+        return await self._admin_mutation(
+            "emailDrafts:createDraft",
+            {
+                "external_id": external_id,
+                "thread_id": thread_id,
+                "run_id": run_id,
+                "to_name": to_name,
+                "to_email": to_email,
+                "subject": subject,
+                "body": body,
+                "from_name": from_name,
+                "from_email": from_email,
+                "signature": signature,
+            },
+        )
+
     async def upsert_event_room_booking(
         self,
         *,

--- a/agent/runtime/anthropic_adapter.py
+++ b/agent/runtime/anthropic_adapter.py
@@ -379,8 +379,10 @@ _IN_PROCESS_TOOLS: list[dict[str, Any]] = [
     {
         "name": "send_outreach_email",
         "description": (
-            "Send an outreach email to a recipient via AgentMail. "
-            "Approval-gated — the runtime will pause for explicit user approval before sending."
+            "Draft an outreach email and show it to the user as an editable card "
+            "in the conversation timeline. The user reviews, edits if needed, and "
+            "sends it themselves. The email is NOT sent by this call — never tell "
+            "the user the email has been sent."
         ),
         "input_schema": {
             "type": "object",

--- a/agent/runtime/context_assembler.py
+++ b/agent/runtime/context_assembler.py
@@ -8,6 +8,7 @@ from .contracts import ContextLinkRecord, MessageRecord, ThreadRecord
 RECENT_MESSAGE_COUNT = 15
 _LINE_TRIM = 240
 _OLDER_BLOCK_CAP = 2000
+_DRAFT_BODY_TRIM = 1200
 
 
 @dataclass(slots=True)
@@ -22,6 +23,7 @@ def assemble_thread_context(
     messages: list[MessageRecord],
     context_links: list[ContextLinkRecord],
     base_system_prompt: str,
+    email_drafts: list[dict] | None = None,
 ) -> ThreadExecutionContext:
     """Convert normalized thread state into model-ready context."""
     finalized = sorted(
@@ -62,10 +64,59 @@ def assemble_thread_context(
         if compressed:
             sections.append(f"## Older thread context\n{compressed}")
 
+    drafts_section = _render_email_drafts(email_drafts or [])
+    if drafts_section:
+        sections.append(drafts_section)
+
     system_prompt = "\n\n".join(sections)
     api_messages = _to_api_messages(recent)
 
     return ThreadExecutionContext(system_prompt=system_prompt, messages=api_messages)
+
+
+def _render_email_drafts(drafts: list[dict]) -> str | None:
+    """Render the user-editable outreach drafts that are still unsent.
+
+    Only drafts with status == 'draft' show up (sent / failed / discarded
+    drafts are noise for the model). Each entry includes the current
+    recipient, subject, and body — these may have been edited by the user
+    in the timeline card since the model last drafted, so the model must
+    treat what it sees here as the latest state, not its own prior output.
+    """
+    active = [d for d in drafts if (d or {}).get("status") == "draft"]
+    if not active:
+        return None
+
+    lines = [
+        "## Pending email drafts",
+        (
+            "The user has these outreach emails drafted but not yet sent. They "
+            "can edit any field inline before sending. The body shown here is "
+            "the user's latest version — the user may have refined what you "
+            "originally drafted. If asked to refine a draft, call "
+            "`send_outreach_email` again with the updated content; the new "
+            "draft will appear in the timeline and the user can discard the "
+            "old one."
+        ),
+        "",
+    ]
+    for d in active:
+        to_name = (d.get("to_name") or "").strip()
+        to_email = (d.get("to_email") or "").strip()
+        recipient = (
+            f"{to_name} <{to_email}>" if to_name and to_email else (to_email or "<no recipient>")
+        )
+        subject = (d.get("subject") or "").strip() or "<no subject>"
+        body = (d.get("body") or "").strip()
+        if len(body) > _DRAFT_BODY_TRIM:
+            body = body[:_DRAFT_BODY_TRIM] + "…"
+        external_id = d.get("external_id") or "<unknown>"
+        lines.append(f"- {external_id} | to: {recipient} | subject: {subject}")
+        if body:
+            indented = "\n".join(f"    {ln}" for ln in body.splitlines())
+            lines.append("  body:")
+            lines.append(indented)
+    return "\n".join(lines)
 
 
 def _compress_older_messages(messages: list[MessageRecord]) -> str:

--- a/agent/runtime/contracts.py
+++ b/agent/runtime/contracts.py
@@ -192,6 +192,21 @@ class ApprovalRecord(BaseModel):
     updated_at: int
 
 
+class EmailDraftRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str
+    thread_external_id: str
+    run_external_id: str | None = None
+    to_name: str
+    to_email: str
+    subject: str
+    body: str
+    from_name: str | None = None
+    from_email: str | None = None
+    signature: str | None = None
+
+
 class StreamEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/agent/runtime/convex_sync.py
+++ b/agent/runtime/convex_sync.py
@@ -11,6 +11,7 @@ from .contracts import (
     ApprovalRecord,
     ArtifactRecord,
     ContextLinkRecord,
+    EmailDraftRecord,
     MessageRecord,
     RunRecord,
     ThreadRecord,
@@ -256,6 +257,37 @@ class ConvexAgentStateSync:
                 return await sb.mutation("agentState:upsertContextLink", args)
         except Exception as exc:
             logger.warning("Convex context-link sync failed: %s", exc)
+            return None
+
+    async def upsert_email_draft(self, record: EmailDraftRecord) -> str | None:
+        if not self._enabled:
+            return None
+
+        thread_convex_id = await self._ensure_thread_convex_id(record.thread_external_id)
+        run_convex_id = (
+            await self._ensure_run_convex_id(record.run_external_id)
+            if record.run_external_id
+            else None
+        )
+        if not thread_convex_id:
+            return None
+
+        try:
+            async with ConvexClient() as sb:
+                return await sb.create_email_draft(
+                    external_id=record.external_id,
+                    thread_id=thread_convex_id,
+                    run_id=run_convex_id,
+                    to_name=record.to_name,
+                    to_email=record.to_email,
+                    subject=record.subject,
+                    body=record.body,
+                    from_name=record.from_name,
+                    from_email=record.from_email,
+                    signature=record.signature,
+                )
+        except Exception as exc:
+            logger.warning("Convex email draft sync failed: %s", exc)
             return None
 
     async def fetch_approval_thread_id(self, approval_external_id: str) -> str | None:

--- a/agent/runtime/policy.py
+++ b/agent/runtime/policy.py
@@ -89,9 +89,11 @@ WRITE_TOOL_NAMES = {
     "book_oncehub_room",
 }
 
-SEND_TOOL_NAMES = {
-    "send_outreach_email",
-}
+SEND_TOOL_NAMES: set[str] = set()
+# Note: `send_outreach_email` used to live here. The in-conversation tool
+# now writes an editable draft to Convex (via _draft_outreach_email in
+# tool_executor.py) and returns immediately; sending is initiated by the
+# user from /api/agent/email/send. No approval pause is needed.
 
 
 def infer_tool_action_from_tool_name(tool_name: str, payload: dict | None = None) -> ToolAction:

--- a/agent/runtime/run_context.py
+++ b/agent/runtime/run_context.py
@@ -1,0 +1,50 @@
+"""Per-run context exposed to in-process tool handlers.
+
+The Anthropic tool loop in ``run_agent`` does not know which thread / run
+it belongs to — that belongs to the runtime service. Tools that need to
+write thread-scoped state (e.g. the email-draft handler) read this
+context to find the active ``thread_external_id`` and ``run_external_id``
+without changing every tool signature.
+
+Set via :func:`use_run_context` on the runtime service before invoking
+``run_agent``; the contextvar is async-safe (each task copies the
+context, propagation across ``await`` is automatic).
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+
+@dataclass(frozen=True)
+class RunContext:
+    thread_external_id: str
+    run_external_id: str
+    sync: Any  # ConvexAgentStateSync — typed as Any to avoid import cycle
+
+
+_current: ContextVar[RunContext | None] = ContextVar(
+    "agent_run_context", default=None
+)
+
+
+def get_run_context() -> RunContext | None:
+    return _current.get()
+
+
+@contextmanager
+def use_run_context(
+    *, thread_external_id: str, run_external_id: str, sync: Any
+) -> Iterator[RunContext]:
+    ctx = RunContext(
+        thread_external_id=thread_external_id,
+        run_external_id=run_external_id,
+        sync=sync,
+    )
+    token = _current.set(ctx)
+    try:
+        yield ctx
+    finally:
+        _current.reset(token)

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -1304,11 +1304,25 @@ class AgentRuntimeService:
                 system_prompt=DEFAULT_SYSTEM_PROMPT(),
                 messages=[],
             )
+
+        # Email drafts live only in Convex, not the in-memory runtime store.
+        # Fetch them so the model sees the current state of any unsent drafts
+        # — including edits the user made in the timeline card after the
+        # original draft was generated.
+        email_drafts: list[dict] = []
+        if self._sync.enabled:
+            convex_state = await self._sync.fetch_thread_state(thread_id)
+            if isinstance(convex_state, dict):
+                raw = convex_state.get("email_drafts") or []
+                if isinstance(raw, list):
+                    email_drafts = [d for d in raw if isinstance(d, dict)]
+
         return assemble_thread_context(
             thread=thread,
             messages=messages,
             context_links=context_links,
             base_system_prompt=DEFAULT_SYSTEM_PROMPT(),
+            email_drafts=email_drafts,
         )
 
     def _retry_system_prompt(self, base_system: str, expectation: RequestToolExpectation | None) -> str:

--- a/agent/runtime/service.py
+++ b/agent/runtime/service.py
@@ -38,6 +38,7 @@ from .normalize import (
     text_block,
 )
 from .policy import ApprovalPolicy, ToolAction, infer_tool_action_from_text
+from .run_context import use_run_context
 from .store import InMemoryRuntimeStore
 from .tool_expectations import (
     RequestToolExpectation,
@@ -376,7 +377,12 @@ class AgentRuntimeService:
                 detail_json=json.dumps({"tool": action_label, "input": tool_payload}),
             )
             try:
-                tool_result = await execute_tool_call(action_label, tool_payload)
+                with use_run_context(
+                    thread_external_id=run.thread_external_id,
+                    run_external_id=run.external_id,
+                    sync=self._sync,
+                ):
+                    tool_result = await execute_tool_call(action_label, tool_payload)
             except Exception as exc:
                 await self._emit_trace(
                     thread_id=run.thread_external_id,
@@ -567,10 +573,15 @@ class AgentRuntimeService:
     async def _execute_tool_aware_run(self, *, run: RunRecord, user_input: str, context: ThreadExecutionContext) -> None:
         expectation = infer_request_tool_expectation(user_input)
         try:
-            result = await self._adapter.run_agent(
-                messages=context.messages,
-                system_prompt=context.system_prompt,
-            )
+            with use_run_context(
+                thread_external_id=run.thread_external_id,
+                run_external_id=run.external_id,
+                sync=self._sync,
+            ):
+                result = await self._adapter.run_agent(
+                    messages=context.messages,
+                    system_prompt=context.system_prompt,
+                )
         except Exception as exc:
             await self._emit_trace(
                 thread_id=run.thread_external_id,
@@ -602,10 +613,15 @@ class AgentRuntimeService:
                 detail_json=json.dumps({"kind": expectation.kind if expectation else "unknown"}),
             )
             try:
-                result = await self._adapter.run_agent(
-                    messages=context.messages,
-                    system_prompt=self._retry_system_prompt(context.system_prompt, expectation),
-                )
+                with use_run_context(
+                    thread_external_id=run.thread_external_id,
+                    run_external_id=run.external_id,
+                    sync=self._sync,
+                ):
+                    result = await self._adapter.run_agent(
+                        messages=context.messages,
+                        system_prompt=self._retry_system_prompt(context.system_prompt, expectation),
+                    )
             except Exception as exc:
                 await self._mark_run_error(run=run, message=str(exc))
                 return

--- a/agent/runtime/tool_executor.py
+++ b/agent/runtime/tool_executor.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from typing import Any, Awaitable, Callable
+from uuid import uuid4
+
+from .contracts import EmailDraftRecord
+from .run_context import get_run_context
 
 try:
     from apps.mcp.service import (
@@ -22,7 +26,6 @@ try:
         search_contacts,
         search_people,
         search_speakers,
-        send_outreach_email,
         update_event_safe,
         update_speaker_workflow,
         upsert_person,
@@ -47,11 +50,74 @@ except ModuleNotFoundError:  # pragma: no cover - package import fallback
         search_contacts,
         search_people,
         search_speakers,
-        send_outreach_email,
         update_event_safe,
         update_speaker_workflow,
         upsert_person,
     )
+
+
+async def _draft_outreach_email(
+    *,
+    recipient_name: str,
+    recipient_email: str,
+    subject: str,
+    message_body: str,
+    sender_name: str = "",
+    sender_email: str = "",
+    signature: str = "",
+) -> dict[str, Any]:
+    """In-conversation outreach: persist a draft, return immediately.
+
+    The draft is rendered as an editable card in the timeline; the user
+    sends it via the Next.js /api/agent/email/send route. The agent
+    runtime never invokes AgentMail itself — that prevents the run
+    from blocking on user review.
+    """
+    ctx = get_run_context()
+    if ctx is None:
+        return {
+            "draft_id": None,
+            "status": "draft_not_persisted",
+            "message": (
+                "Email draft could not be persisted because no run context is "
+                "active. The user did not see this draft."
+            ),
+        }
+
+    external_id = f"draft_{uuid4().hex}"
+    record = EmailDraftRecord(
+        external_id=external_id,
+        thread_external_id=ctx.thread_external_id,
+        run_external_id=ctx.run_external_id,
+        to_name=recipient_name,
+        to_email=recipient_email,
+        subject=subject,
+        body=message_body,
+        from_name=sender_name or None,
+        from_email=sender_email or None,
+        signature=signature or None,
+    )
+
+    persisted_id = await ctx.sync.upsert_email_draft(record)
+    if persisted_id is None:
+        return {
+            "draft_id": external_id,
+            "status": "draft_not_persisted",
+            "message": (
+                "Email draft could not be persisted (storage unavailable). "
+                "Tell the user the draft was prepared but not shown — they "
+                "will need to retry."
+            ),
+        }
+
+    return {
+        "draft_id": external_id,
+        "status": "draft_pending_user_review",
+        "message": (
+            "Email draft created and shown to the user as an editable card. "
+            "Do NOT say the email was sent — the user will review and send it."
+        ),
+    }
 
 ToolHandler = Callable[..., Awaitable[Any]]
 
@@ -81,8 +147,9 @@ TOOL_HANDLERS: dict[str, ToolHandler] = {
     "find_oncehub_slots": find_oncehub_slots,
     "book_oncehub_room": book_oncehub_room,
     "get_event_room_booking": get_event_room_booking,
-    # outreach email
-    "send_outreach_email": send_outreach_email,
+    # outreach email — in-conversation tool drafts an email card; the FE
+    # sends it via /api/agent/email/send. See _draft_outreach_email above.
+    "send_outreach_email": _draft_outreach_email,
 }
 
 

--- a/agent/tests/test_email_draft_handler.py
+++ b/agent/tests/test_email_draft_handler.py
@@ -1,0 +1,123 @@
+"""Unit tests for the in-conversation email-draft handler.
+
+Covers _draft_outreach_email in runtime/tool_executor.py:
+- writes a draft via the run-context sync object
+- returns a status the model can read without claiming the email was sent
+- handles the "no run context" and "sync unavailable" edge cases gracefully
+"""
+from __future__ import annotations
+
+import pytest
+
+from runtime.contracts import EmailDraftRecord
+from runtime.run_context import use_run_context
+from runtime.tool_executor import _draft_outreach_email
+
+
+class _FakeSync:
+    """Minimal stand-in for ConvexAgentStateSync."""
+
+    def __init__(self, *, persisted_id: str | None = "agent_email_drafts:1") -> None:
+        self._persisted_id = persisted_id
+        self.calls: list[EmailDraftRecord] = []
+
+    async def upsert_email_draft(self, record: EmailDraftRecord) -> str | None:
+        self.calls.append(record)
+        return self._persisted_id
+
+
+@pytest.mark.asyncio
+async def test_draft_persists_and_returns_pending_review() -> None:
+    sync = _FakeSync()
+    with use_run_context(
+        thread_external_id="thread_abc",
+        run_external_id="run_xyz",
+        sync=sync,
+    ):
+        result = await _draft_outreach_email(
+            recipient_name="Jane Doe",
+            recipient_email="jane@example.com",
+            subject="Speaking at Fintech 2026",
+            message_body="Hi Jane, …",
+            signature="— Tech@NYU",
+        )
+
+    assert result["status"] == "draft_pending_user_review"
+    assert isinstance(result["draft_id"], str)
+    assert result["draft_id"].startswith("draft_")
+    # Hard requirement: the model must not be told the email was sent.
+    assert "sent" not in result["message"].lower() or "not" in result["message"].lower()
+
+    assert len(sync.calls) == 1
+    record = sync.calls[0]
+    assert record.thread_external_id == "thread_abc"
+    assert record.run_external_id == "run_xyz"
+    assert record.to_email == "jane@example.com"
+    assert record.subject == "Speaking at Fintech 2026"
+    assert record.body == "Hi Jane, …"
+    assert record.signature == "— Tech@NYU"
+    assert record.external_id == result["draft_id"]
+
+
+@pytest.mark.asyncio
+async def test_draft_without_run_context_returns_not_persisted() -> None:
+    # No `use_run_context(...)` wrapper: simulating the tool being called
+    # outside the runtime loop.
+    result = await _draft_outreach_email(
+        recipient_name="Jane Doe",
+        recipient_email="jane@example.com",
+        subject="Hi",
+        message_body="Body",
+    )
+    assert result["status"] == "draft_not_persisted"
+    assert result["draft_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_draft_falls_back_when_sync_returns_none() -> None:
+    # Simulates Convex being disabled or the mutation returning None.
+    sync = _FakeSync(persisted_id=None)
+    with use_run_context(
+        thread_external_id="thread_abc",
+        run_external_id="run_xyz",
+        sync=sync,
+    ):
+        result = await _draft_outreach_email(
+            recipient_name="Jane",
+            recipient_email="jane@example.com",
+            subject="Hi",
+            message_body="Body",
+        )
+    assert result["status"] == "draft_not_persisted"
+    # The draft id is still surfaced so the model has something to reference,
+    # but the message must explicitly tell the model the user did not see it.
+    assert result["draft_id"] is not None
+    assert "retry" in result["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_draft_optional_sender_fields_are_none_when_blank() -> None:
+    sync = _FakeSync()
+    with use_run_context(
+        thread_external_id="thread_abc",
+        run_external_id="run_xyz",
+        sync=sync,
+    ):
+        await _draft_outreach_email(
+            recipient_name="Jane",
+            recipient_email="jane@example.com",
+            subject="Hi",
+            message_body="Body",
+        )
+    record = sync.calls[0]
+    assert record.from_name is None
+    assert record.from_email is None
+    assert record.signature is None
+
+
+def test_send_outreach_email_handler_is_the_draft_function() -> None:
+    # Sanity: the runtime tool registry binds the model-facing tool name
+    # to the draft-only handler, never to the AgentMail-sending function.
+    from runtime.tool_executor import TOOL_HANDLERS
+
+    assert TOOL_HANDLERS["send_outreach_email"] is _draft_outreach_email

--- a/agent/tests/test_runtime_harness.py
+++ b/agent/tests/test_runtime_harness.py
@@ -278,6 +278,105 @@ async def test_assemble_context_empty_links_no_malformed_section() -> None:
     assert "Context Links" not in ctx.system_prompt
 
 
+@pytest.mark.asyncio
+async def test_assemble_context_renders_active_email_drafts() -> None:
+    """Active email drafts surface in the system prompt so the model can
+    refine them on user request — including the body the user may have
+    edited in the timeline card."""
+    from runtime.contracts import ThreadRecord, Channel
+    from time import time
+    now = int(time() * 1000)
+    thread = ThreadRecord(
+        external_id="t1", channel=Channel.WEB, created_at=now, updated_at=now
+    )
+    drafts = [
+        {
+            "external_id": "draft_xyz",
+            "status": "draft",
+            "to_name": "Jane Doe",
+            "to_email": "jane@example.com",
+            "subject": "Speaking at NYU",
+            "body": "Hi Jane,\n\nUser-edited body goes here.",
+        }
+    ]
+    ctx = assemble_thread_context(
+        thread=thread,
+        messages=[],
+        context_links=[],
+        base_system_prompt="BASE",
+        email_drafts=drafts,
+    )
+    assert "Pending email drafts" in ctx.system_prompt
+    assert "draft_xyz" in ctx.system_prompt
+    assert "jane@example.com" in ctx.system_prompt
+    assert "Speaking at NYU" in ctx.system_prompt
+    assert "User-edited body goes here." in ctx.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_filters_terminal_drafts_from_prompt() -> None:
+    """Sent / failed / discarded drafts must not appear; only status='draft'."""
+    from runtime.contracts import ThreadRecord, Channel
+    from time import time
+    now = int(time() * 1000)
+    thread = ThreadRecord(
+        external_id="t1", channel=Channel.WEB, created_at=now, updated_at=now
+    )
+    drafts = [
+        {
+            "external_id": "draft_old_sent",
+            "status": "sent",
+            "to_email": "shipped@example.com",
+            "subject": "Already gone",
+            "body": "—",
+        },
+        {
+            "external_id": "draft_discarded",
+            "status": "discarded",
+            "to_email": "noop@example.com",
+            "subject": "Discarded",
+            "body": "—",
+        },
+        {
+            "external_id": "draft_failed",
+            "status": "failed",
+            "to_email": "bounced@example.com",
+            "subject": "Failed",
+            "body": "—",
+        },
+    ]
+    ctx = assemble_thread_context(
+        thread=thread,
+        messages=[],
+        context_links=[],
+        base_system_prompt="BASE",
+        email_drafts=drafts,
+    )
+    assert "Pending email drafts" not in ctx.system_prompt
+    assert "shipped@example.com" not in ctx.system_prompt
+    assert "noop@example.com" not in ctx.system_prompt
+    assert "bounced@example.com" not in ctx.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_no_drafts_section_when_empty() -> None:
+    """If no drafts are passed, the section is omitted entirely."""
+    from runtime.contracts import ThreadRecord, Channel
+    from time import time
+    now = int(time() * 1000)
+    thread = ThreadRecord(
+        external_id="t1", channel=Channel.WEB, created_at=now, updated_at=now
+    )
+    ctx = assemble_thread_context(
+        thread=thread,
+        messages=[],
+        context_links=[],
+        base_system_prompt="BASE",
+        email_drafts=[],
+    )
+    assert "Pending email drafts" not in ctx.system_prompt
+
+
 # ---------------------------------------------------------------------------
 # Thread-aware run integration tests
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_runtime_policy.py
+++ b/agent/tests/test_runtime_policy.py
@@ -38,17 +38,19 @@ def test_infer_tool_action_detects_send() -> None:
     assert action.action_class == ActionClass.SEND
 
 
-def test_infer_tool_action_from_tool_name_send_outreach_email() -> None:
+def test_infer_tool_action_from_tool_name_send_outreach_email_is_now_analyze() -> None:
+    # send_outreach_email no longer triggers an approval pause: the in-conversation
+    # tool persists an editable draft and returns immediately. Sending happens
+    # via the Next.js /api/agent/email/send route, not the agent runtime.
     action = infer_tool_action_from_tool_name(
         "send_outreach_email",
         payload={"tool_input": {"recipient_email": "ada@example.com"}},
     )
-    assert action.action_class == ActionClass.SEND
+    assert action.action_class == ActionClass.ANALYZE
     assert action.name == "send_outreach_email"
 
 
-def test_send_outreach_email_requires_approval() -> None:
+def test_send_outreach_email_does_not_require_approval() -> None:
     action = infer_tool_action_from_tool_name("send_outreach_email")
     decision = ApprovalPolicy().evaluate(action)
-    assert decision.requires_approval
-    assert decision.risk_level == RiskLevel.MEDIUM
+    assert not decision.requires_approval

--- a/fe+convex/app/api/agent/email/send/route.ts
+++ b/fe+convex/app/api/agent/email/send/route.ts
@@ -1,10 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ConvexHttpClient } from "convex/browser";
-import { getSessionCookie } from "better-auth/cookies";
 import { AgentMailClient } from "agentmail";
 import { api } from "@/convex/_generated/api";
 
 export const dynamic = "force-dynamic";
+
+interface ValidatedSession {
+  userId: string;
+}
+
+/**
+ * Validate the Better Auth session by hitting the auth get-session endpoint
+ * with the request's cookies. Mere presence of a session cookie (the
+ * `getSessionCookie` helper) is not sufficient — that only checks for a
+ * cookie, not a live session.
+ */
+async function validateSession(
+  request: NextRequest
+): Promise<ValidatedSession | null> {
+  const cookie = request.headers.get("cookie");
+  if (!cookie) return null;
+  const url = new URL("/api/auth/get-session", request.url);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { cookie },
+      cache: "no-store",
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const data = (await res.json().catch(() => null)) as
+    | { user?: { id?: unknown } }
+    | null;
+  const userId = data?.user?.id;
+  return typeof userId === "string" && userId.length > 0
+    ? { userId }
+    : null;
+}
 
 interface SendBody {
   draft_id?: unknown;
@@ -30,10 +64,35 @@ function agentToken(): string | undefined {
 }
 
 export async function POST(request: NextRequest) {
-  // Better Auth session check — same lightweight pattern used by middleware.ts.
-  // Without this, an unauthenticated POST could trigger an outbound send.
-  if (!getSessionCookie(request)) {
+  // Real Better Auth session validation. Cookie-presence checks (as used by
+  // middleware.ts as a perf optimization) are not sufficient here — this
+  // route triggers outbound email, so we need a live, server-validated
+  // session and an active admin membership before proceeding.
+  const session = await validateSession(request);
+  if (!session) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const token = agentToken();
+  if (!token) {
+    return NextResponse.json(
+      { error: "AGENT_SERVICE_TOKEN is not configured on the server" },
+      { status: 500 }
+    );
+  }
+
+  const sb = convex();
+  let isAdmin: boolean;
+  try {
+    isAdmin = await sb.query(api.eboard.isAdminByUserId, {
+      userId: session.userId,
+      _agent_token: token,
+    });
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   let body: SendBody;
@@ -71,14 +130,41 @@ export async function POST(request: NextRequest) {
   const inboxId =
     process.env.AGENTMAIL_INBOX_ID ?? "events-technyu@agentmail.to";
 
-  const sb = convex();
-  const token = agentToken();
+  // Step 1: persist the latest in-card field values before locking the draft.
+  // The FE blurs and immediately POSTs, so an in-flight `updateDraftFields`
+  // mutation may lose the race against `markSending` and silently fail
+  // (status check rejects edits to non-`draft` rows). Doing the field
+  // update server-side, before the lock, removes that race.
+  try {
+    await sb.mutation(api.emailDrafts.updateDraftFields, {
+      external_id: draftId,
+      to_name: toName,
+      to_email: toEmail,
+      subject,
+      body: messageBody,
+      _agent_token: token,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        status: "failed",
+        error:
+          err instanceof Error
+            ? err.message
+            : "Could not persist draft fields",
+      },
+      { status: 409 }
+    );
+  }
 
-  // Step 1: flip the draft to "sending" so the FE card shows progress.
-  // If this fails (e.g. terminal status), we don't attempt the send.
+  // Step 2: flip the draft to "sending" so the FE card shows progress.
+  // If this fails (e.g. already sending / terminal status), we don't
+  // attempt the send. `markSending` only accepts rows still in `draft`,
+  // which is the lock against double-submits.
   try {
     await sb.mutation(api.emailDrafts.markSending, {
       external_id: draftId,
+      sent_by_user_id: session.userId,
       _agent_token: token,
     });
   } catch (err) {
@@ -91,7 +177,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Step 2: send via AgentMail.
+  // Step 3: send via AgentMail.
   const client = new AgentMailClient({ apiKey });
   const fullText = signature
     ? `${messageBody.trimEnd()}\n\n${signature}`

--- a/fe+convex/app/api/agent/email/send/route.ts
+++ b/fe+convex/app/api/agent/email/send/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { getSessionCookie } from "better-auth/cookies";
+import { AgentMailClient } from "agentmail";
+import { api } from "@/convex/_generated/api";
+
+export const dynamic = "force-dynamic";
+
+interface SendBody {
+  draft_id?: unknown;
+  to_name?: unknown;
+  to_email?: unknown;
+  subject?: unknown;
+  body?: unknown;
+  from_name?: unknown;
+  from_email?: unknown;
+  signature?: unknown;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function convex() {
+  return new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+}
+
+function agentToken(): string | undefined {
+  return process.env.AGENT_SERVICE_TOKEN;
+}
+
+export async function POST(request: NextRequest) {
+  // Better Auth session check — same lightweight pattern used by middleware.ts.
+  // Without this, an unauthenticated POST could trigger an outbound send.
+  if (!getSessionCookie(request)) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  let body: SendBody;
+  try {
+    body = (await request.json()) as SendBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const draftId = asString(body.draft_id);
+  const toName = asString(body.to_name);
+  const toEmail = asString(body.to_email);
+  const subject = asString(body.subject);
+  const messageBody = asString(body.body);
+  const signature = asString(body.signature);
+
+  if (!draftId || !toEmail || !subject || !messageBody) {
+    return NextResponse.json(
+      {
+        error:
+          "draft_id, to_email, subject, and body are required",
+      },
+      { status: 400 }
+    );
+  }
+
+  const apiKey = process.env.AGENTMAIL_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "AGENTMAIL_API_KEY is not configured on the server" },
+      { status: 500 }
+    );
+  }
+
+  const inboxId =
+    process.env.AGENTMAIL_INBOX_ID ?? "events-technyu@agentmail.to";
+
+  const sb = convex();
+  const token = agentToken();
+
+  // Step 1: flip the draft to "sending" so the FE card shows progress.
+  // If this fails (e.g. terminal status), we don't attempt the send.
+  try {
+    await sb.mutation(api.emailDrafts.markSending, {
+      external_id: draftId,
+      _agent_token: token,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        status: "failed",
+        error: err instanceof Error ? err.message : "Could not mark draft as sending",
+      },
+      { status: 409 }
+    );
+  }
+
+  // Step 2: send via AgentMail.
+  const client = new AgentMailClient({ apiKey });
+  const fullText = signature
+    ? `${messageBody.trimEnd()}\n\n${signature}`
+    : messageBody;
+
+  try {
+    const recipient = toName ? `${toName} <${toEmail}>` : toEmail;
+    const result = await client.inboxes.messages.send(inboxId, {
+      to: recipient,
+      subject,
+      text: fullText,
+      labels: ["outreach"],
+    });
+
+    await sb.mutation(api.emailDrafts.markSent, {
+      external_id: draftId,
+      agentmail_message_id: result.messageId,
+      sent_at: Date.now(),
+      _agent_token: token,
+    });
+
+    return NextResponse.json({
+      status: "sent",
+      message_id: result.messageId,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "AgentMail send failed";
+    try {
+      await sb.mutation(api.emailDrafts.markFailed, {
+        external_id: draftId,
+        error_message: message,
+        _agent_token: token,
+      });
+    } catch {
+      /* swallow — Convex unavailable; original error still surfaces */
+    }
+    return NextResponse.json({ status: "failed", error: message }, { status: 502 });
+  }
+}

--- a/fe+convex/bun.lock
+++ b/fe+convex/bun.lock
@@ -6,6 +6,7 @@
       "name": "my-app",
       "dependencies": {
         "@convex-dev/better-auth": "^0.10.13",
+        "@x402/fetch": "^2.11.0",
         "agentmail": "^0.5.1",
         "better-auth": "1.4.9",
         "class-variance-authority": "^0.7.1",
@@ -44,6 +45,8 @@
     "unrs-resolver",
   ],
   "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -314,7 +317,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
@@ -480,6 +483,12 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@simplewebauthn/browser": ["@simplewebauthn/browser@13.2.2", "", {}, "sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA=="],
@@ -635,6 +644,12 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@x402/core": ["@x402/core@2.11.0", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw=="],
+
+    "@x402/fetch": ["@x402/fetch@2.11.0", "", { "dependencies": { "@x402/core": "~2.11.0", "viem": "^2.39.3", "zod": "^3.24.2" } }, "sha512-sDkoq1ZZt10/UVa75bCXTbWkXMbPOOQpkdSxWB0ybHtlmqT7PM6hU4DVCov4iL792W1Oi38VtxfUw5EkvdvYtw=="],
+
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -1188,6 +1203,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
@@ -1451,6 +1468,8 @@
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
+
+    "ox": ["ox@0.14.20", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -1790,6 +1809,8 @@
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
+    "viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1860,6 +1881,12 @@
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -1880,6 +1907,10 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@x402/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@x402/fetch/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "better-call/@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
@@ -1893,6 +1924,8 @@
     "convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -1932,6 +1965,12 @@
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
@@ -1945,6 +1984,10 @@
     "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/fe+convex/bun.lock
+++ b/fe+convex/bun.lock
@@ -6,6 +6,7 @@
       "name": "my-app",
       "dependencies": {
         "@convex-dev/better-auth": "^0.10.13",
+        "agentmail": "^0.5.1",
         "better-auth": "1.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -642,6 +643,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "agentmail": ["agentmail@0.5.1", "", { "dependencies": { "ws": "^8.20.0" } }, "sha512-LMPYMqhpeZxHxfUcf919SNbzagle24ek+9mtdYpDtUfBWu/nePeU5GeFsPGwEpo6wrPJdtyPZIVj7++yhhDeVQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -1805,7 +1808,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -1886,6 +1889,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 

--- a/fe+convex/components/agent/ConversationTimeline.tsx
+++ b/fe+convex/components/agent/ConversationTimeline.tsx
@@ -4,10 +4,17 @@ import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import type { AgentMessage, AgentApproval, AgentThread, AgentTraceStep } from "./types";
+import type {
+  AgentMessage,
+  AgentApproval,
+  AgentEmailDraft,
+  AgentThread,
+  AgentTraceStep,
+} from "./types";
 import { MessageBubble } from "./MessageBubble";
 import { ResolvedApprovalCard } from "./ResolvedApprovalCard";
 import { ToolCallCard } from "./ToolCallCard";
+import { EmailDraftCard } from "./EmailDraftCard";
 import { ComposerApprovalPrompt } from "./ComposerApprovalPrompt";
 import { AgentInput, type AgentInputHandle } from "./AgentInput";
 import {
@@ -74,6 +81,26 @@ type ConvexTrace = {
   created_at: number;
 };
 
+type ConvexEmailDraft = {
+  external_id: string;
+  thread_id: string;
+  run_id?: string | null;
+  status: string;
+  to_name: string;
+  to_email: string;
+  subject: string;
+  body: string;
+  from_name?: string | null;
+  from_email?: string | null;
+  signature?: string | null;
+  agentmail_message_id?: string | null;
+  error_message?: string | null;
+  sent_at?: number | null;
+  sent_by_user_id?: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
 function mapConvexMessage(msg: ConvexMessage): AgentMessage {
   const content = msg.content_blocks.map((block) => {
     if (block.kind === "text" || block.kind === "markdown") {
@@ -133,6 +160,28 @@ function mapConvexTrace(t: ConvexTrace): AgentTraceStep {
   };
 }
 
+function mapConvexEmailDraft(d: ConvexEmailDraft): AgentEmailDraft {
+  return {
+    id: d.external_id,
+    threadId: d.thread_id as string,
+    runId: (d.run_id as string | null) ?? undefined,
+    status: d.status as AgentEmailDraft["status"],
+    toName: d.to_name,
+    toEmail: d.to_email,
+    subject: d.subject,
+    body: d.body,
+    fromName: d.from_name ?? undefined,
+    fromEmail: d.from_email ?? undefined,
+    signature: d.signature ?? undefined,
+    agentmailMessageId: d.agentmail_message_id ?? undefined,
+    errorMessage: d.error_message ?? undefined,
+    sentAt: d.sent_at ?? undefined,
+    sentByUserId: d.sent_by_user_id ?? undefined,
+    createdAt: d.created_at,
+    updatedAt: d.updated_at,
+  };
+}
+
 function deriveTitle(text: string): string {
   const MAX = 60;
   const trimmed = text.trim();
@@ -185,6 +234,12 @@ export function ConversationTimeline({
 
   const traces: AgentTraceStep[] = threadState
     ? ((threadState.traces as unknown as ConvexTrace[]) ?? []).map(mapConvexTrace)
+    : [];
+
+  const emailDrafts: AgentEmailDraft[] = threadState
+    ? (
+        (threadState as { email_drafts?: ConvexEmailDraft[] }).email_drafts ?? []
+      ).map(mapConvexEmailDraft)
     : [];
 
   const loaded = thread ? threadState !== undefined : true;
@@ -367,16 +422,31 @@ export function ConversationTimeline({
   type TimelineItem =
     | { kind: "message"; id: string; createdAt: number; message: AgentMessage }
     | { kind: "approval"; id: string; createdAt: number; approval: AgentApproval }
-    | { kind: "tool_call"; id: string; createdAt: number; trace: AgentTraceStep };
+    | { kind: "tool_call"; id: string; createdAt: number; trace: AgentTraceStep }
+    | { kind: "email_draft"; id: string; createdAt: number; draft: AgentEmailDraft };
 
   const toolCallTraces = traces.filter(
     (t) => t.kind === "tool_completion" || t.kind === "tool_failure",
   );
 
+  // Filter the redundant tool-completion trace for `send_outreach_email`:
+  // the EmailDraftCard already renders the user-visible state for that tool,
+  // so the small "send_outreach_email" pill would be noise.
+  const filteredToolCallTraces = toolCallTraces.filter((t) => {
+    if (!t.detailJson) return true;
+    try {
+      const detail = JSON.parse(t.detailJson) as { tool?: string };
+      return detail.tool !== "send_outreach_email";
+    } catch {
+      return true;
+    }
+  });
+
   const timeline: TimelineItem[] = [
     ...messages.map((m) => ({ kind: "message" as const, id: m.id, createdAt: m.createdAt, message: m })),
     ...resolvedApprovals.map((a) => ({ kind: "approval" as const, id: a.id, createdAt: a.createdAt, approval: a })),
-    ...toolCallTraces.map((t) => ({ kind: "tool_call" as const, id: t.id, createdAt: t.createdAt, trace: t })),
+    ...filteredToolCallTraces.map((t) => ({ kind: "tool_call" as const, id: t.id, createdAt: t.createdAt, trace: t })),
+    ...emailDrafts.map((d) => ({ kind: "email_draft" as const, id: d.id, createdAt: d.createdAt, draft: d })),
   ].sort((a, b) => a.createdAt - b.createdAt);
 
   // Only suppress ThinkingBubble once a streaming message has actual text to show.
@@ -432,6 +502,8 @@ export function ConversationTimeline({
                 <MessageBubble key={item.id} message={item.message} />
               ) : item.kind === "approval" ? (
                 <ResolvedApprovalCard key={item.id} approval={item.approval} />
+              ) : item.kind === "email_draft" ? (
+                <EmailDraftCard key={item.id} draft={item.draft} />
               ) : (
                 <ToolCallCard key={item.id} trace={item.trace} />
               )

--- a/fe+convex/components/agent/EmailDraftCard.tsx
+++ b/fe+convex/components/agent/EmailDraftCard.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation } from "convex/react";
+import { Mail, Send, Trash2 } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import type { AgentEmailDraft, EmailDraftStatus } from "./types";
+
+interface EmailDraftCardProps {
+  draft: AgentEmailDraft;
+}
+
+interface SendResponse {
+  status: "sent" | "failed";
+  message_id?: string;
+  error?: string;
+}
+
+const STATUS_LABEL: Record<EmailDraftStatus, string> = {
+  draft: "PENDING_ACTION: SEND_EMAIL",
+  sending: "SENDING…",
+  sent: "SENT",
+  failed: "SEND FAILED",
+  discarded: "DISCARDED",
+};
+
+function shortId(id: string): string {
+  // "draft_8f4fa178…1224b" → "8F4F-1224B" style label.
+  const stem = id.replace(/^draft_/, "");
+  if (stem.length <= 9) return stem.toUpperCase();
+  return `${stem.slice(0, 4).toUpperCase()}-${stem.slice(-5).toUpperCase()}`;
+}
+
+export function EmailDraftCard({ draft }: EmailDraftCardProps) {
+  const updateDraftFields = useMutation(api.emailDrafts.updateDraftFields);
+  const markDiscarded = useMutation(api.emailDrafts.markDiscarded);
+
+  const editable = draft.status === "draft";
+
+  const [toName, setToName] = useState(draft.toName);
+  const [toEmail, setToEmail] = useState(draft.toEmail);
+  const [subject, setSubject] = useState(draft.subject);
+  const [body, setBody] = useState(draft.body);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Re-sync local state when the upstream draft changes (Convex live query).
+  useEffect(() => {
+    setToName(draft.toName);
+    setToEmail(draft.toEmail);
+    setSubject(draft.subject);
+    setBody(draft.body);
+  }, [draft.toName, draft.toEmail, draft.subject, draft.body]);
+
+  async function persistField(
+    field: "to_name" | "to_email" | "subject" | "body",
+    value: string
+  ) {
+    if (!editable) return;
+    try {
+      await updateDraftFields({
+        external_id: draft.id,
+        [field]: value,
+      } as never);
+    } catch (err) {
+      // Silent retry on next blur; surface in console for diagnostics.
+      console.warn("Failed to persist draft edit", err);
+    }
+  }
+
+  async function handleSend() {
+    if (!editable || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const res = await fetch("/api/agent/email/send", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          draft_id: draft.id,
+          to_name: toName,
+          to_email: toEmail,
+          subject,
+          body,
+          from_name: draft.fromName,
+          from_email: draft.fromEmail,
+          signature: draft.signature,
+        }),
+      });
+      const json = (await res.json()) as SendResponse;
+      if (!res.ok || json.status !== "sent") {
+        setSubmitError(json.error || "Send failed");
+      }
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Send failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDiscard() {
+    if (!editable || submitting) return;
+    if (!window.confirm("Discard this draft? It will not be sent.")) return;
+    try {
+      await markDiscarded({ external_id: draft.id });
+    } catch (err) {
+      console.warn("Failed to discard draft", err);
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[640px] overflow-hidden rounded-[12px] border border-[#E0E0E0] bg-white shadow-sm">
+      <div className="flex items-center justify-between bg-[#0A0A0A] px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <Mail className="h-3.5 w-3.5 text-white" strokeWidth={2.2} />
+          <span className="font-mono text-[11.5px] font-semibold tracking-wider text-white">
+            {STATUS_LABEL[draft.status]}
+          </span>
+        </div>
+        <span className="font-mono text-[11px] text-[#9A9A9A]">
+          ID: {shortId(draft.id)}
+        </span>
+      </div>
+
+      <div className="space-y-3 px-4 py-4">
+        <FieldRow label="TO">
+          <div className="flex flex-1 items-center gap-2">
+            <input
+              type="text"
+              value={toName}
+              onChange={(e) => setToName(e.target.value)}
+              onBlur={() => persistField("to_name", toName)}
+              disabled={!editable}
+              placeholder="Recipient name"
+              className="w-32 bg-transparent text-[13px] text-[#111111] placeholder:text-[#BBBBBB] focus:outline-none disabled:opacity-60"
+            />
+            <span className="text-[12px] text-[#999999]">·</span>
+            <input
+              type="email"
+              value={toEmail}
+              onChange={(e) => setToEmail(e.target.value)}
+              onBlur={() => persistField("to_email", toEmail)}
+              disabled={!editable}
+              placeholder="email@example.com"
+              className="flex-1 bg-transparent text-[13px] text-[#111111] placeholder:text-[#BBBBBB] focus:outline-none disabled:opacity-60"
+            />
+          </div>
+        </FieldRow>
+
+        <FieldRow label="SUBJ">
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            onBlur={() => persistField("subject", subject)}
+            disabled={!editable}
+            placeholder="Subject line"
+            className="w-full bg-transparent text-[13px] font-medium text-[#111111] placeholder:text-[#BBBBBB] focus:outline-none disabled:opacity-60"
+          />
+        </FieldRow>
+
+        <div className="rounded-[8px] border border-[#E8E8E8] bg-[#FAFAFA] px-3 py-2.5 transition-colors focus-within:border-[#CFCFCF] focus-within:bg-white">
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            onBlur={() => persistField("body", body)}
+            disabled={!editable}
+            rows={6}
+            placeholder="Email body…"
+            className="w-full resize-y bg-transparent text-[13px] leading-[1.55] text-[#111111] placeholder:text-[#BBBBBB] focus:outline-none disabled:opacity-60"
+            style={{ fontFamily: "var(--font-app-sans)" }}
+          />
+        </div>
+
+        {draft.status === "failed" && draft.errorMessage && (
+          <p className="rounded-[6px] bg-[#FFF3F3] px-3 py-2 text-[12px] text-[#A8002C]">
+            {draft.errorMessage}
+          </p>
+        )}
+        {submitError && draft.status === "draft" && (
+          <p className="rounded-[6px] bg-[#FFF3F3] px-3 py-2 text-[12px] text-[#A8002C]">
+            {submitError}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-[#EFEFEF] bg-[#FAFAFA] px-4 py-2.5">
+        <button
+          type="button"
+          onClick={handleDiscard}
+          disabled={!editable || submitting}
+          className="flex items-center gap-1.5 text-[12px] font-medium text-[#777777] transition-colors hover:text-[#A8002C] disabled:opacity-40"
+        >
+          <Trash2 className="h-3.5 w-3.5" strokeWidth={2.2} />
+          Discard
+        </button>
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={!editable || submitting || !toEmail || !subject}
+          className="flex items-center gap-1.5 rounded-[6px] bg-[#0A0A0A] px-3 py-1.5 text-[12px] font-semibold text-white transition-all hover:bg-[#222222] active:scale-[0.97] disabled:bg-[#E0E0E0] disabled:text-[#BBBBBB]"
+        >
+          <Send className="h-3.5 w-3.5" strokeWidth={2.2} />
+          {submitting ? "Sending…" : draft.status === "sent" ? "Sent" : "Send"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-12 shrink-0 font-mono text-[10.5px] font-semibold tracking-wider text-[#999999]">
+        {label}
+      </span>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/fe+convex/components/agent/EmailDraftCard.tsx
+++ b/fe+convex/components/agent/EmailDraftCard.tsx
@@ -73,6 +73,23 @@ export function EmailDraftCard({ draft }: EmailDraftCardProps) {
     setSubmitting(true);
     setSubmitError(null);
     try {
+      // Flush local edits before kicking off the send so we don't race the
+      // unawaited blur-time mutation against `markSending`. The send route
+      // also persists these fields server-side as a second line of defense,
+      // but doing it here keeps the Convex live query consistent for any
+      // other tabs viewing this thread.
+      try {
+        await updateDraftFields({
+          external_id: draft.id,
+          to_name: toName,
+          to_email: toEmail,
+          subject,
+          body,
+        });
+      } catch {
+        /* ignore — server route will re-persist before locking */
+      }
+
       const res = await fetch("/api/agent/email/send", {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/fe+convex/components/agent/adapters/runtime.ts
+++ b/fe+convex/components/agent/adapters/runtime.ts
@@ -326,6 +326,10 @@ export async function getThreadState(threadId: string): Promise<AgentThreadState
     artifacts: state.artifacts.map(mapArtifact),
     approvals: state.approvals.map(mapApproval),
     traces: (state.traces ?? []).map(mapTrace),
+    // Email drafts live in Convex (not the Modal runtime); the live-query
+    // path in ConversationTimeline.tsx surfaces them. The HTTP adapter
+    // returns an empty list for now.
+    emailDrafts: [],
   };
 }
 

--- a/fe+convex/components/agent/types.ts
+++ b/fe+convex/components/agent/types.ts
@@ -155,6 +155,33 @@ export interface AgentRun {
   finishedAt?: number;
 }
 
+export type EmailDraftStatus =
+  | "draft"
+  | "sending"
+  | "sent"
+  | "failed"
+  | "discarded";
+
+export interface AgentEmailDraft {
+  id: string;
+  threadId: string;
+  runId?: string;
+  status: EmailDraftStatus;
+  toName: string;
+  toEmail: string;
+  subject: string;
+  body: string;
+  fromName?: string;
+  fromEmail?: string;
+  signature?: string;
+  agentmailMessageId?: string;
+  errorMessage?: string;
+  sentAt?: number;
+  sentByUserId?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface AgentThreadState {
   thread: AgentThread;
   runs: AgentRun[];
@@ -162,4 +189,5 @@ export interface AgentThreadState {
   artifacts: AgentArtifact[];
   approvals: AgentApproval[];
   traces: AgentTraceStep[];
+  emailDrafts: AgentEmailDraft[];
 }

--- a/fe+convex/convex/_generated/api.d.ts
+++ b/fe+convex/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as attendance from "../attendance.js";
 import type * as auth from "../auth.js";
 import type * as contactAssignments from "../contactAssignments.js";
 import type * as eboard from "../eboard.js";
+import type * as emailDrafts from "../emailDrafts.js";
 import type * as events from "../events.js";
 import type * as http from "../http.js";
 import type * as inboundDashboard from "../inboundDashboard.js";
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   contactAssignments: typeof contactAssignments;
   eboard: typeof eboard;
+  emailDrafts: typeof emailDrafts;
   events: typeof events;
   http: typeof http;
   inboundDashboard: typeof inboundDashboard;

--- a/fe+convex/convex/agentState.test.ts
+++ b/fe+convex/convex/agentState.test.ts
@@ -22,7 +22,8 @@ type TableName =
   | "agent_artifacts"
   | "agent_approvals"
   | "agent_traces"
-  | "agent_context_links";
+  | "agent_context_links"
+  | "agent_email_drafts";
 
 type TableRow = { _id: string } & Record<string, unknown>;
 type Tables = Record<TableName, TableRow[]>;
@@ -74,6 +75,7 @@ class FakeDb {
     agent_approvals: 0,
     agent_traces: 0,
     agent_context_links: 0,
+    agent_email_drafts: 0,
   };
 
   readonly tables: Tables = {
@@ -84,6 +86,7 @@ class FakeDb {
     agent_approvals: [],
     agent_traces: [],
     agent_context_links: [],
+    agent_email_drafts: [],
   };
 
   query(table: TableName) {

--- a/fe+convex/convex/agentState.trace.test.ts
+++ b/fe+convex/convex/agentState.trace.test.ts
@@ -38,7 +38,8 @@ type TableName =
   | "agent_artifacts"
   | "agent_approvals"
   | "agent_traces"
-  | "agent_context_links";
+  | "agent_context_links"
+  | "agent_email_drafts";
 
 type TableRow = { _id: string } & Record<string, unknown>;
 type Tables = Record<TableName, TableRow[]>;
@@ -90,6 +91,7 @@ class FakeDb {
     agent_approvals: 0,
     agent_traces: 0,
     agent_context_links: 0,
+    agent_email_drafts: 0,
   };
 
   readonly tables: Tables = {
@@ -100,6 +102,7 @@ class FakeDb {
     agent_approvals: [],
     agent_traces: [],
     agent_context_links: [],
+    agent_email_drafts: [],
   };
 
   query(table: TableName) {

--- a/fe+convex/convex/agentState.ts
+++ b/fe+convex/convex/agentState.ts
@@ -199,32 +199,37 @@ export const getThreadState = query({
     const thread = await requireThread(ctx, args);
     if (!thread) return null;
 
-    const [runs, messages, artifacts, approvals, traces, context_links] = await Promise.all([
-      ctx.db
-        .query("agent_runs")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-      ctx.db
-        .query("agent_messages")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-      ctx.db
-        .query("agent_artifacts")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-      ctx.db
-        .query("agent_approvals")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-      ctx.db
-        .query("agent_traces")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-      ctx.db
-        .query("agent_context_links")
-        .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
-        .collect(),
-    ]);
+    const [runs, messages, artifacts, approvals, traces, context_links, email_drafts] =
+      await Promise.all([
+        ctx.db
+          .query("agent_runs")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_messages")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_artifacts")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_approvals")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_traces")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_context_links")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+        ctx.db
+          .query("agent_email_drafts")
+          .withIndex("by_thread_id", (q) => q.eq("thread_id", thread._id))
+          .collect(),
+      ]);
 
     return {
       thread,
@@ -234,6 +239,7 @@ export const getThreadState = query({
       approvals: sortByRequestedDesc(approvals),
       traces: sortBySequenceAsc(traces),
       context_links: sortByCreatedAsc(context_links),
+      email_drafts: sortByCreatedAsc(email_drafts),
     };
   },
 });

--- a/fe+convex/convex/eboard.ts
+++ b/fe+convex/convex/eboard.ts
@@ -40,6 +40,30 @@ export async function requireAdminOrAgent(
   return { ...result, isAgent: false } as const;
 }
 
+/**
+ * Internal admin lookup for server-side Next.js routes that have already
+ * validated a Better Auth session and need to confirm the user is an active
+ * admin before invoking agent-token-bypassed mutations. Gated by
+ * AGENT_SERVICE_TOKEN so untrusted clients can't probe membership.
+ */
+export const isAdminByUserId = query({
+  args: {
+    userId: v.string(),
+    _agent_token: v.string(),
+  },
+  handler: async (ctx, { userId, _agent_token }) => {
+    const expected = process.env.AGENT_SERVICE_TOKEN;
+    if (!expected || _agent_token !== expected) {
+      throw new Error("Forbidden");
+    }
+    const member = await ctx.db
+      .query("eboard_members")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+    return !!(member && member.active && member.role === "admin");
+  },
+});
+
 export const getCurrentMember = query({
   args: {},
   handler: async (ctx) => {

--- a/fe+convex/convex/emailDrafts.test.ts
+++ b/fe+convex/convex/emailDrafts.test.ts
@@ -304,7 +304,61 @@ describe("emailDrafts", () => {
       getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
         external_id: "draft_xyz",
       })
-    ).rejects.toThrow(/already finalized/);
+    ).rejects.toThrow(/cannot be sent/);
+  });
+
+  test("markSending refuses to re-lock a draft already in 'sending' (double-submit guard)", async () => {
+    const { createDraft, markSending } = await draftsModulePromise;
+    const { ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+
+    // A second concurrent send attempt sees status=sending and must bail
+    // before the API route can call AgentMail a second time.
+    await expect(
+      getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+        external_id: "draft_xyz",
+      })
+    ).rejects.toThrow(/cannot be sent.*sending/);
+  });
+
+  test("markSending leaves error_message untouched (no undefined patch)", async () => {
+    const { createDraft, markSending, markFailed } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+    expect(db.rows("agent_email_drafts")[0]).not.toHaveProperty("error_message");
+    // Even after a failure → re-create cycle, markSending must not write
+    // `undefined` (which violates the project's definedPatch convention).
+    await getHandler<{ external_id: string; error_message: string }, string>(markFailed)(
+      ctx as never,
+      { external_id: "draft_xyz", error_message: "boom" }
+    );
+    expect(db.rows("agent_email_drafts")[0]).toMatchObject({
+      status: "failed",
+      error_message: "boom",
+    });
+  });
+
+  test("getDraftByExternalId rejects unauthenticated callers", async () => {
+    const { createDraft, getDraftByExternalId } = await draftsModulePromise;
+    const { ctx } = createHarness();
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+
+    requireAdminMemberImpl = async () => {
+      throw new Error("Admin access required");
+    };
+    await expect(
+      getHandler<{ external_id: string }, unknown>(getDraftByExternalId)(ctx as never, {
+        external_id: "draft_xyz",
+      })
+    ).rejects.toThrow("Admin access required");
   });
 
   test("markDiscarded refuses to discard a sent draft", async () => {

--- a/fe+convex/convex/emailDrafts.test.ts
+++ b/fe+convex/convex/emailDrafts.test.ts
@@ -1,0 +1,370 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type TableName = "agent_email_drafts";
+type TableRow = { _id: string } & Record<string, unknown>;
+type Tables = Record<TableName, TableRow[]>;
+
+let requireAdminMemberImpl = async () => ({
+  authUser: { _id: "user:1" },
+  member: { role: "admin" },
+});
+
+mock.module("./eboard", () => ({
+  requireAdminMember: (...args: unknown[]) => requireAdminMemberImpl(...args),
+  requireAdminOrAgent: async (ctx: unknown, agentToken: string | undefined) => {
+    const expected = process.env.AGENT_SERVICE_TOKEN;
+    if (expected && agentToken && agentToken === expected) {
+      return { authUser: null, member: null, isAgent: true } as const;
+    }
+    const result = await requireAdminMemberImpl();
+    return { ...result, isAgent: false } as const;
+  },
+}));
+
+class FakeIndexRangeBuilder {
+  readonly filters: Array<[string, unknown]> = [];
+  eq(field: string, value: unknown) {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+class FakeQuery {
+  constructor(
+    private readonly rows: TableRow[],
+    private readonly filters: Array<[string, unknown]> = []
+  ) {}
+
+  withIndex(_indexName: string, build: (b: FakeIndexRangeBuilder) => unknown) {
+    const builder = new FakeIndexRangeBuilder();
+    build(builder);
+    return new FakeQuery(this.rows, builder.filters);
+  }
+
+  async unique() {
+    const matches = this.rows.filter((row) =>
+      this.filters.every(([field, value]) => row[field] === value)
+    );
+    if (matches.length > 1) throw new Error("Expected unique row, got multiple");
+    return matches[0] ?? null;
+  }
+
+  async collect() {
+    return this.rows.filter((row) =>
+      this.filters.every(([field, value]) => row[field] === value)
+    );
+  }
+}
+
+class FakeDb {
+  private counter = 0;
+  readonly tables: Tables = { agent_email_drafts: [] };
+
+  query(table: TableName) {
+    return new FakeQuery(this.tables[table]);
+  }
+
+  async get(id: string) {
+    const table = id.split(":")[0] as TableName;
+    return this.tables[table].find((row) => row._id === id) ?? null;
+  }
+
+  async insert(table: TableName, value: Record<string, unknown>) {
+    const id = `${table}:${++this.counter}`;
+    this.tables[table].push({ _id: id, ...value });
+    return id;
+  }
+
+  async patch(id: string, value: Record<string, unknown>) {
+    const table = id.split(":")[0] as TableName;
+    const index = this.tables[table].findIndex((row) => row._id === id);
+    if (index === -1) throw new Error(`Missing row: ${id}`);
+    this.tables[table][index] = { ...this.tables[table][index], ...value };
+  }
+
+  rows(table: TableName) {
+    return [...this.tables[table]];
+  }
+}
+
+function getHandler<TArgs, TResult>(fn: unknown) {
+  const wrapped = fn as {
+    handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+    _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
+  };
+  const handler = wrapped.handler ?? wrapped._handler;
+  if (!handler) throw new Error("Convex handler unavailable in test harness");
+  return handler;
+}
+
+function installConvexHandlerAliases(functions: unknown[]) {
+  for (const fn of functions) {
+    const wrapped = fn as { handler?: unknown; _handler?: unknown };
+    if (!wrapped.handler) wrapped.handler = wrapped._handler;
+  }
+}
+
+function createHarness() {
+  const db = new FakeDb();
+  return { db, ctx: { db } };
+}
+
+const draftsModulePromise = import("./emailDrafts");
+
+const baseDraftArgs = {
+  external_id: "draft_xyz",
+  thread_id: "agent_threads:1",
+  to_name: "Jane Doe",
+  to_email: "jane@example.com",
+  subject: "Speaking at Fintech 2026",
+  body: "Hi Jane, …",
+};
+
+beforeAll(async () => {
+  const mod = await draftsModulePromise;
+  installConvexHandlerAliases([
+    mod.createDraft,
+    mod.getDraftByExternalId,
+    mod.updateDraftFields,
+    mod.markSending,
+    mod.markSent,
+    mod.markFailed,
+    mod.markDiscarded,
+  ]);
+});
+
+beforeEach(() => {
+  requireAdminMemberImpl = async () => ({
+    authUser: { _id: "user:1" },
+    member: { role: "admin" },
+  });
+});
+
+describe("emailDrafts", () => {
+  test("createDraft requires admin/agent and inserts a draft row", async () => {
+    const { createDraft } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    requireAdminMemberImpl = async () => {
+      throw new Error("Admin access required");
+    };
+    await expect(
+      getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs)
+    ).rejects.toThrow("Admin access required");
+
+    requireAdminMemberImpl = async () => ({
+      authUser: { _id: "user:1" },
+      member: { role: "admin" },
+    });
+    const id = await getHandler<typeof baseDraftArgs, string>(createDraft)(
+      ctx as never,
+      baseDraftArgs
+    );
+    expect(await db.get(id)).toMatchObject({
+      external_id: "draft_xyz",
+      status: "draft",
+      to_name: "Jane Doe",
+      to_email: "jane@example.com",
+      subject: "Speaking at Fintech 2026",
+    });
+  });
+
+  test("createDraft is idempotent on repeated external_id", async () => {
+    const { createDraft } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    const first = await getHandler<typeof baseDraftArgs, string>(createDraft)(
+      ctx as never,
+      baseDraftArgs
+    );
+    const second = await getHandler<typeof baseDraftArgs, string>(createDraft)(
+      ctx as never,
+      { ...baseDraftArgs, subject: "Different subject" }
+    );
+    expect(first).toBe(second);
+    expect(db.rows("agent_email_drafts")).toHaveLength(1);
+    // Original subject preserved — subsequent create attempts don't overwrite.
+    expect(db.rows("agent_email_drafts")[0].subject).toBe("Speaking at Fintech 2026");
+  });
+
+  test("updateDraftFields patches editable fields while status=draft", async () => {
+    const { createDraft, updateDraftFields, getDraftByExternalId } = await draftsModulePromise;
+    const { ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+
+    await getHandler<
+      {
+        external_id: string;
+        subject?: string;
+        body?: string;
+      },
+      string
+    >(updateDraftFields)(ctx as never, {
+      external_id: "draft_xyz",
+      subject: "Updated subject",
+      body: "Updated body",
+    });
+
+    const after = await getHandler<{ external_id: string }, unknown>(getDraftByExternalId)(
+      ctx as never,
+      { external_id: "draft_xyz" }
+    );
+    expect(after).toMatchObject({
+      subject: "Updated subject",
+      body: "Updated body",
+      to_email: "jane@example.com", // untouched
+    });
+  });
+
+  test("updateDraftFields rejects edits after the draft has moved past 'draft'", async () => {
+    const { createDraft, updateDraftFields, markSending } = await draftsModulePromise;
+    const { ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+
+    await expect(
+      getHandler<
+        { external_id: string; subject?: string },
+        string
+      >(updateDraftFields)(ctx as never, {
+        external_id: "draft_xyz",
+        subject: "Too late",
+      })
+    ).rejects.toThrow(/cannot be edited/);
+  });
+
+  test("markSending → markSent flips status, sets agentmail_message_id and sent_at", async () => {
+    const { createDraft, markSending, markSent } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string; sent_by_user_id?: string }, string>(markSending)(
+      ctx as never,
+      { external_id: "draft_xyz", sent_by_user_id: "user:7" }
+    );
+    expect(db.rows("agent_email_drafts")[0]).toMatchObject({
+      status: "sending",
+      sent_by_user_id: "user:7",
+    });
+
+    await getHandler<
+      { external_id: string; agentmail_message_id: string; sent_at?: number },
+      string
+    >(markSent)(ctx as never, {
+      external_id: "draft_xyz",
+      agentmail_message_id: "am_msg_42",
+      sent_at: 12345,
+    });
+    expect(db.rows("agent_email_drafts")[0]).toMatchObject({
+      status: "sent",
+      agentmail_message_id: "am_msg_42",
+      sent_at: 12345,
+    });
+  });
+
+  test("markFailed records error_message and leaves draft sendable for follow-ups", async () => {
+    const { createDraft, markSending, markFailed } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+    await getHandler<{ external_id: string; error_message: string }, string>(markFailed)(
+      ctx as never,
+      { external_id: "draft_xyz", error_message: "AgentMail 503" }
+    );
+    expect(db.rows("agent_email_drafts")[0]).toMatchObject({
+      status: "failed",
+      error_message: "AgentMail 503",
+    });
+  });
+
+  test("markSending refuses to re-send a terminal draft", async () => {
+    const { createDraft, markSending, markSent } = await draftsModulePromise;
+    const { ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+    await getHandler<
+      { external_id: string; agentmail_message_id: string },
+      string
+    >(markSent)(ctx as never, {
+      external_id: "draft_xyz",
+      agentmail_message_id: "am_msg_1",
+    });
+
+    await expect(
+      getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+        external_id: "draft_xyz",
+      })
+    ).rejects.toThrow(/already finalized/);
+  });
+
+  test("markDiscarded refuses to discard a sent draft", async () => {
+    const { createDraft, markSending, markSent, markDiscarded } = await draftsModulePromise;
+    const { ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markSending)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+    await getHandler<
+      { external_id: string; agentmail_message_id: string },
+      string
+    >(markSent)(ctx as never, {
+      external_id: "draft_xyz",
+      agentmail_message_id: "am_msg_1",
+    });
+
+    await expect(
+      getHandler<{ external_id: string }, string>(markDiscarded)(ctx as never, {
+        external_id: "draft_xyz",
+      })
+    ).rejects.toThrow(/already finalized/);
+  });
+
+  test("markDiscarded transitions an unsent draft", async () => {
+    const { createDraft, markDiscarded } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    await getHandler<typeof baseDraftArgs, string>(createDraft)(ctx as never, baseDraftArgs);
+    await getHandler<{ external_id: string }, string>(markDiscarded)(ctx as never, {
+      external_id: "draft_xyz",
+    });
+    expect(db.rows("agent_email_drafts")[0]).toMatchObject({ status: "discarded" });
+  });
+
+  test("agent token bypasses admin gate", async () => {
+    process.env.AGENT_SERVICE_TOKEN = "token-abc";
+    requireAdminMemberImpl = async () => {
+      throw new Error("Admin access required");
+    };
+
+    const { createDraft } = await draftsModulePromise;
+    const { db, ctx } = createHarness();
+
+    const id = await getHandler<typeof baseDraftArgs & { _agent_token?: string }, string>(
+      createDraft
+    )(ctx as never, { ...baseDraftArgs, _agent_token: "token-abc" });
+    expect(await db.get(id)).toMatchObject({ status: "draft" });
+
+    delete process.env.AGENT_SERVICE_TOKEN;
+  });
+
+  test("getDraftByExternalId returns null for missing drafts", async () => {
+    const { getDraftByExternalId } = await draftsModulePromise;
+    const { ctx } = createHarness();
+    const result = await getHandler<{ external_id: string }, unknown>(getDraftByExternalId)(
+      ctx as never,
+      { external_id: "draft_missing" }
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/fe+convex/convex/emailDrafts.ts
+++ b/fe+convex/convex/emailDrafts.ts
@@ -1,0 +1,212 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireAdminOrAgent } from "./eboard";
+
+const TERMINAL_STATUSES = new Set(["sent", "failed", "discarded"]);
+
+export const getDraftByExternalId = query({
+  args: { external_id: v.string() },
+  handler: async (ctx, { external_id }) => {
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    return draft ?? null;
+  },
+});
+
+export const createDraft = mutation({
+  args: {
+    external_id: v.string(),
+    thread_id: v.id("agent_threads"),
+    run_id: v.optional(v.id("agent_runs")),
+    to_name: v.string(),
+    to_email: v.string(),
+    subject: v.string(),
+    body: v.string(),
+    from_name: v.optional(v.string()),
+    from_email: v.optional(v.string()),
+    signature: v.optional(v.string()),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { _agent_token, external_id, ...rest } = args;
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const existing = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (existing) {
+      // Idempotent — agent retries shouldn't create duplicate drafts.
+      return existing._id;
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert("agent_email_drafts", {
+      external_id,
+      ...rest,
+      status: "draft",
+      created_at: now,
+      updated_at: now,
+    });
+  },
+});
+
+export const updateDraftFields = mutation({
+  args: {
+    external_id: v.string(),
+    to_name: v.optional(v.string()),
+    to_email: v.optional(v.string()),
+    subject: v.optional(v.string()),
+    body: v.optional(v.string()),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { _agent_token, external_id, ...patch } = args;
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (!draft) throw new Error(`Email draft not found: ${external_id}`);
+    if (draft.status !== "draft") {
+      throw new Error(
+        `Email draft ${external_id} cannot be edited (status=${draft.status})`
+      );
+    }
+
+    const fields: Record<string, unknown> = {};
+    if (patch.to_name !== undefined) fields.to_name = patch.to_name;
+    if (patch.to_email !== undefined) fields.to_email = patch.to_email;
+    if (patch.subject !== undefined) fields.subject = patch.subject;
+    if (patch.body !== undefined) fields.body = patch.body;
+    if (Object.keys(fields).length === 0) return draft._id;
+
+    fields.updated_at = Date.now();
+    await ctx.db.patch(draft._id, fields);
+    return draft._id;
+  },
+});
+
+export const markSending = mutation({
+  args: {
+    external_id: v.string(),
+    sent_by_user_id: v.optional(v.string()),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { external_id, sent_by_user_id, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (!draft) throw new Error(`Email draft not found: ${external_id}`);
+    if (TERMINAL_STATUSES.has(draft.status)) {
+      throw new Error(
+        `Email draft ${external_id} already finalized (status=${draft.status})`
+      );
+    }
+
+    await ctx.db.patch(draft._id, {
+      status: "sending",
+      sent_by_user_id: sent_by_user_id ?? draft.sent_by_user_id,
+      error_message: undefined,
+      updated_at: Date.now(),
+    });
+    return draft._id;
+  },
+});
+
+export const markSent = mutation({
+  args: {
+    external_id: v.string(),
+    agentmail_message_id: v.string(),
+    sent_at: v.optional(v.number()),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    { external_id, agentmail_message_id, sent_at, _agent_token }
+  ) => {
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (!draft) throw new Error(`Email draft not found: ${external_id}`);
+
+    const now = Date.now();
+    await ctx.db.patch(draft._id, {
+      status: "sent",
+      agentmail_message_id,
+      sent_at: sent_at ?? now,
+      error_message: undefined,
+      updated_at: now,
+    });
+    return draft._id;
+  },
+});
+
+export const markFailed = mutation({
+  args: {
+    external_id: v.string(),
+    error_message: v.string(),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { external_id, error_message, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (!draft) throw new Error(`Email draft not found: ${external_id}`);
+
+    await ctx.db.patch(draft._id, {
+      status: "failed",
+      error_message,
+      updated_at: Date.now(),
+    });
+    return draft._id;
+  },
+});
+
+export const markDiscarded = mutation({
+  args: {
+    external_id: v.string(),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { external_id, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
+
+    const draft = await ctx.db
+      .query("agent_email_drafts")
+      .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
+      .unique();
+    if (!draft) throw new Error(`Email draft not found: ${external_id}`);
+    if (TERMINAL_STATUSES.has(draft.status)) {
+      // Already terminal — discarding a sent message would be misleading.
+      throw new Error(
+        `Email draft ${external_id} already finalized (status=${draft.status})`
+      );
+    }
+
+    await ctx.db.patch(draft._id, {
+      status: "discarded",
+      updated_at: Date.now(),
+    });
+    return draft._id;
+  },
+});
+
+export const VALID_STATUSES = [
+  "draft",
+  "sending",
+  "sent",
+  "failed",
+  "discarded",
+] as const;

--- a/fe+convex/convex/emailDrafts.ts
+++ b/fe+convex/convex/emailDrafts.ts
@@ -5,8 +5,12 @@ import { requireAdminOrAgent } from "./eboard";
 const TERMINAL_STATUSES = new Set(["sent", "failed", "discarded"]);
 
 export const getDraftByExternalId = query({
-  args: { external_id: v.string() },
-  handler: async (ctx, { external_id }) => {
+  args: {
+    external_id: v.string(),
+    _agent_token: v.optional(v.string()),
+  },
+  handler: async (ctx, { external_id, _agent_token }) => {
+    await requireAdminOrAgent(ctx, _agent_token);
     const draft = await ctx.db
       .query("agent_email_drafts")
       .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
@@ -104,18 +108,22 @@ export const markSending = mutation({
       .withIndex("by_external_id", (q) => q.eq("external_id", external_id))
       .unique();
     if (!draft) throw new Error(`Email draft not found: ${external_id}`);
-    if (TERMINAL_STATUSES.has(draft.status)) {
+    // Only `draft` may transition to `sending`. This is the send lock — if two
+    // requests race, only the first sees status `draft` and proceeds; the
+    // second sees `sending`/`sent`/etc. and bails out before AgentMail is
+    // called twice for the same recipient.
+    if (draft.status !== "draft") {
       throw new Error(
-        `Email draft ${external_id} already finalized (status=${draft.status})`
+        `Email draft ${external_id} cannot be sent (status=${draft.status})`
       );
     }
 
-    await ctx.db.patch(draft._id, {
+    const patch: Record<string, unknown> = {
       status: "sending",
-      sent_by_user_id: sent_by_user_id ?? draft.sent_by_user_id,
-      error_message: undefined,
       updated_at: Date.now(),
-    });
+    };
+    if (sent_by_user_id !== undefined) patch.sent_by_user_id = sent_by_user_id;
+    await ctx.db.patch(draft._id, patch);
     return draft._id;
   },
 });
@@ -144,7 +152,6 @@ export const markSent = mutation({
       status: "sent",
       agentmail_message_id,
       sent_at: sent_at ?? now,
-      error_message: undefined,
       updated_at: now,
     });
     return draft._id;

--- a/fe+convex/convex/schema.ts
+++ b/fe+convex/convex/schema.ts
@@ -201,6 +201,34 @@ export default defineSchema({
     .index("by_run_id", ["run_id"])
     .index("by_entity", ["entity_type", "entity_id"]),
 
+  // User-reviewable email drafts emitted by the in-conversation outreach tool.
+  // The agent writes the draft and returns immediately (no approval pause);
+  // the FE renders an editable card in the timeline; the user hits Send,
+  // which goes through /api/agent/email/send (not the agent runtime).
+  agent_email_drafts: defineTable({
+    external_id: v.string(),               // "draft_<uuid>"
+    thread_id: v.id("agent_threads"),
+    run_id: v.optional(v.id("agent_runs")),
+    status: v.string(),                    // draft | sending | sent | failed | discarded
+    to_name: v.string(),
+    to_email: v.string(),
+    subject: v.string(),
+    body: v.string(),
+    from_name: v.optional(v.string()),
+    from_email: v.optional(v.string()),
+    signature: v.optional(v.string()),
+    agentmail_message_id: v.optional(v.string()),
+    error_message: v.optional(v.string()),
+    sent_at: v.optional(v.number()),
+    sent_by_user_id: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_external_id", ["external_id"])
+    .index("by_thread_id", ["thread_id"])
+    .index("by_run_id", ["run_id"])
+    .index("by_status", ["status"]),
+
   eboard_members: defineTable({
     userId: v.string(),             // Better Auth user._id (opaque string)
     role: v.optional(v.string()),

--- a/fe+convex/package.json
+++ b/fe+convex/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "^0.10.13",
+    "agentmail": "^0.5.1",
     "better-auth": "1.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/fe+convex/package.json
+++ b/fe+convex/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "^0.10.13",
+    "@x402/fetch": "^2.11.0",
     "agentmail": "^0.5.1",
     "better-auth": "1.4.9",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
Outreach now flows through an inline editable card in the conversation timeline instead of pausing the agent for a blocking approval prompt. The model emits a draft, the run continues, and the user reviews/edits/sends from the card. Send goes through a new Next.js API route that calls AgentMail directly — the agent runtime is fully out of the loop.

## What changes for the user
- **Before:** the agent says \"I will send an email…\" and the run sits in `paused_approval`; the user clicks Approve/Reject in a fixed bottom panel; the agent runtime then calls AgentMail.
- **After:** the model calls `send_outreach_email`, which persists an editable draft and returns immediately. An `EmailDraftCard` renders inline at that point in the timeline with editable TO / SUBJ / BODY fields, Send + Discard buttons, and live status (`draft → sending → sent | failed | discarded`). The agent thread continues without blocking.

## Architecture
1. **Convex** — new `agent_email_drafts` table + 6 mutations (`createDraft`, `updateDraftFields`, `markSending`, `markSent`, `markFailed`, `markDiscarded`) gated by `requireAdminOrAgent`. `getThreadState` returns drafts so the live query feeds the FE timeline reactively.
2. **Agent runtime — drafting:** `send_outreach_email` is no longer in `SEND_TOOL_NAMES`; the handler in `tool_executor.py` is replaced with `_draft_outreach_email`, which writes to Convex via `ConvexAgentStateSync.upsert_email_draft` and returns a status the model reads. A new `run_context.py` contextvar exposes `{thread_external_id, run_external_id, sync}` to tools without changing every signature. `service.py` wraps `run_agent` (and the post-approval re-execute path) in `use_run_context(...)`.
3. **Agent runtime — refinement context:** unsent drafts (`status == \"draft\"`) for the active thread are fetched from Convex inside `_assemble_context` and rendered as a `## Pending email drafts` section in the system prompt. Each entry shows `draft_id | recipient | subject` plus the (trimmed) body. The body shown is *the user's latest version* — i.e. anything they edited inline in the card — so when a user later asks the model to refine the email (\"shorten the subject\"), the model has the current state and can re-call `send_outreach_email` with the updated content. Sent / failed / discarded drafts are filtered out of the prompt.
4. **FE** — new `EmailDraftCard.tsx`, new `email_draft` branch in `ConversationTimeline`'s timeline-item union, new `AgentEmailDraft` type. Edits persist on blur via `useMutation(api.emailDrafts.updateDraftFields)`; Discard via `markDiscarded`; Send POSTs the latest local field values to `/api/agent/email/send`.
5. **Next.js route** — `/api/agent/email/send` checks the Better Auth session cookie, marks the draft `sending`, calls AgentMail via the official JS SDK, and records `sent` / `failed` back in Convex. Uses `AGENT_SERVICE_TOKEN` to satisfy the admin gate.

## Tests
- [x] **Convex (53/53 pass):** new `emailDrafts.test.ts` covers gating, idempotent re-create, edit window enforced (`status === \"draft\"`), all state transitions including \"already finalized\" guards on `markSending`/`markDiscarded`, agent-token bypass, and 404 on the lookup query. Updated `agentState.test.ts` and `agentState.trace.test.ts` to recognize the new table.
- [x] **Agent (193/193 relevant pass):** `test_email_draft_handler.py` covers the draft handler — payload shape, missing run context, sync failure, optional fields. `test_runtime_policy.py` updated to assert `send_outreach_email` is now `ANALYZE` and never requires approval. Three new `test_runtime_harness.py` cases for the drafts-in-context behavior — render, terminal-status filtering, empty-list omission. (One unrelated `test_attio.py` skipped since it needs `ATTIO_API_KEY` from Doppler.)
- [x] **TypeScript / build:** `bun run build` compiles cleanly.

## Required env
- **FE deploy env (Doppler dev/prd):** add `AGENTMAIL_API_KEY`, `AGENT_SERVICE_TOKEN`, optionally `AGENTMAIL_INBOX_ID` (defaults to `events-technyu@agentmail.to`).
- **Modal already has** `AGENTMAIL_API_KEY` and `AGENT_SERVICE_TOKEN` from PR #84's secret rollout.

## Build dep note
`@x402/fetch` is added as a direct dep so the `agentmail` SDK's dynamic `import(\"@x402/fetch\")` (used by its payment-protocol billing wrapper) resolves under Turbopack. We don't exercise that code path — actual sending uses the standard fetch — but the import has to be resolvable at build time.

## Out of scope (follow-ups)
- The bulk outreach worker in `agent/outreach.py` keeps its direct AgentMail send; this PR only changes the in-conversation tool.
- 'Trace context' header lines on the card (`> Found speaker… > Drafting…` from the mockup) — could later join sibling `agent_traces` rows.
- True 'update existing draft in place' when the model refines (instead of creating a new card alongside the old one) — needs a small Convex query (`getActiveDraftsForThread`) plus a smarter `_draft_outreach_email`.
- Optimistic 'sending' UI; current MVP shows status after the round-trip.
- Multi-recipient drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)