### PR TITLE
Harden OnceHub Convex preflight (PR #85 review follow-up)

### DIFF
--- a/agent/apps/mcp/service.py
+++ b/agent/apps/mcp/service.py
@@ -15,6 +15,7 @@ have been retired because they wrote workflow state onto `people`.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -473,6 +474,22 @@ async def update_event_safe(
 
 # ── OnceHub Room Booking ────────────────────────────────────────────────
 
+# Substrings emitted by Convex when an argument fails validation (e.g. a
+# malformed `event_id` rejected by `v.id("events")`). Treat these as a
+# confirmed bad id rather than a transient outage.
+_CONVEX_ARG_VALIDATION_MARKERS: tuple[str, ...] = (
+    "ArgumentValidationError",
+    "Validator error",
+    "did not pass validator",
+    'v.id("events")',
+)
+
+
+def _is_convex_arg_validation_error(exc: BaseException) -> bool:
+    msg = str(exc)
+    return any(marker in msg for marker in _CONVEX_ARG_VALIDATION_MARKERS)
+
+
 def _slot_to_row(slot: OnceHubSlot) -> dict[str, Any]:
     return slot.to_dict()
 
@@ -549,7 +566,14 @@ async def book_oncehub_room(
                     raise ValueError(f"Event not found: {event_id}")
         except ValueError:
             raise
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
+            # Convex rejected the supplied event_id at argument validation
+            # (e.g. malformed id failing `v.id("events")`). This is a confirmed
+            # bad id, not a transient outage — fail fast before holding a room.
+            if _is_convex_arg_validation_error(exc):
+                raise ValueError(f"Event not found: {event_id}") from exc
             preflight_convex_error = str(exc)
 
     async with OnceHubClient() as oncehub:
@@ -572,7 +596,7 @@ async def book_oncehub_room(
     booked_end_time = local_end.strftime("%-I:%M %p")
 
     event_created = False
-    convex_sync = "ok"
+    convex_sync = "preflight_skipped" if preflight_convex_error else "ok"
     convex_error: str | None = preflight_convex_error
     effective_event_id = event_id
 

--- a/agent/tests/test_oncehub_mcp_service.py
+++ b/agent/tests/test_oncehub_mcp_service.py
@@ -6,6 +6,7 @@ payload-shaping, event-creation, and booking-receipt persistence logic.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
@@ -293,9 +294,73 @@ async def test_book_oncehub_room_does_not_block_on_convex_preflight_failure(
     assert len(state["booking_calls"]) == 1
     assert result["booking_reference"] == "bk_1"
     assert result["event_id"] == "evt_existing"
-    assert result["convex_sync"] == "ok"
+    assert result["convex_sync"] == "preflight_skipped"
     assert result["preflight_convex_error"] == "Convex preflight unavailable"
     assert "Convex preflight unavailable" in (result["convex_error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_book_oncehub_room_fails_fast_on_convex_arg_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed event_id makes Convex reject `events:getEvent` at argument
+    validation. That is a confirmed bad id, not a transient outage — the tool
+    must NOT submit the irreversible OnceHub booking.
+    """
+    state = _install_fakes(monkeypatch)
+
+    class ValidationConvex(FakeConvexClient):
+        async def get_event(self, event_id: str) -> dict | None:
+            raise RuntimeError(
+                'ArgumentValidationError: Value "not-a-real-id" does not match '
+                'validator v.id("events")'
+            )
+
+    monkeypatch.setattr(mcp_service, "ConvexClient", lambda: ValidationConvex(state))
+
+    tz = ZoneInfo("America/New_York")
+    epoch = int(datetime(2026, 5, 16, 10, 0, tzinfo=tz).timestamp() * 1000)
+
+    with pytest.raises(ValueError, match="Event not found: not-a-real-id"):
+        await mcp_service.book_oncehub_room(
+            slot_start_epoch_ms=epoch,
+            duration_minutes=60,
+            title="Workshop",
+            num_attendees=20,
+            event_id="not-a-real-id",
+        )
+
+    assert state["booking_calls"] == []
+    assert state["upsert_booking_calls"] == []
+
+
+@pytest.mark.asyncio
+async def test_book_oncehub_room_propagates_cancellation_during_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation must propagate so a cancelled task does not still hold a room."""
+    state = _install_fakes(monkeypatch)
+
+    class CancellingConvex(FakeConvexClient):
+        async def get_event(self, event_id: str) -> dict | None:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(mcp_service, "ConvexClient", lambda: CancellingConvex(state))
+
+    tz = ZoneInfo("America/New_York")
+    epoch = int(datetime(2026, 5, 16, 10, 0, tzinfo=tz).timestamp() * 1000)
+
+    with pytest.raises(asyncio.CancelledError):
+        await mcp_service.book_oncehub_room(
+            slot_start_epoch_ms=epoch,
+            duration_minutes=60,
+            title="Workshop",
+            num_attendees=20,
+            event_id="evt_existing",
+        )
+
+    assert state["booking_calls"] == []
+    assert state["upsert_booking_calls"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #85 addressing the three review comments. Tightens the Convex preflight in `book_oncehub_room` so it fails fast on confirmed bad ids and on cancellation, and reports a non-`"ok"` sync state when validation was skipped.

## Review comments addressed

- **P1 — Reject invalid Convex event ids before booking** (chatgpt-codex-connector). Previously a malformed `event_id` made Convex reject `events:getEvent` at argument validation (`v.id("events")`); the broad `except Exception` swallowed it as a transient outage and the irreversible OnceHub booking still ran. The preflight now detects Convex argument-validation errors and raises `ValueError("Event not found: <id>")` before any room is held.
- **CancelledError handling** (copilot-pull-request-reviewer). The preflight `except Exception` also caught `asyncio.CancelledError`, letting a cancelled task proceed to the OnceHub booking. Now `asyncio.CancelledError` is re-raised explicitly; only operational Convex errors become `preflight_convex_error`.
- **`convex_sync` consistency** (copilot-pull-request-reviewer). When preflight was skipped, the payload set `convex_sync = "ok"` while populating `convex_error`. The state is now `"preflight_skipped"` (and remains `"failed"` on post-booking sync failure), so callers that read `convex_sync == "ok"` get a coherent view.

## Changes

- `agent/apps/mcp/service.py`: add `_is_convex_arg_validation_error` helper; preflight re-raises `ValueError` / `asyncio.CancelledError` and converts Convex argument-validation errors into `ValueError`; `convex_sync` defaults to `"preflight_skipped"` when preflight was skipped.
- `agent/tests/test_oncehub_mcp_service.py`: add regression tests for the malformed-id and cancellation paths; update the existing preflight-outage test to expect `"preflight_skipped"`.

## Tests

```bash
cd agent && uv run --frozen python -m pytest tests/test_oncehub_mcp_service.py -q
# 10 passed
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmmCGh5ajjc22P3uBddieV)_